### PR TITLE
Secreatures Hotfix #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ twitch_client_id
 msgqueue
 vcs.xml
 ewdebug.py
+.vscode/launch.json

--- a/client.py
+++ b/client.py
@@ -104,9 +104,12 @@ cmd_map = {
 	ewcfg.cmd_annoint: ewwep.annoint,
 	ewcfg.cmd_annoint_alt1: ewwep.annoint,
 
-	#Marry and divorce your current wepaon.
+	# Marry and divorce your current weapon.
 	ewcfg.cmd_marry: ewwep.marry,
 	ewcfg.cmd_divorce: ewwep.divorce,
+	
+	# Crush a poudrin to get some slime.
+	ewcfg.cmd_crush: ewjuviecmd.crush,
 
 	# move from juvenile to one of the armies (rowdys or killers)
 	ewcfg.cmd_enlist: ewjuviecmd.enlist,

--- a/ew.py
+++ b/ew.py
@@ -37,6 +37,7 @@ class EwUser:
 	time_last_action = 0
 	weaponmarried = False
 	arrested = False
+	splattered_slimes = 0
 
 	time_lastkill = 0
 	time_lastrevive = 0
@@ -485,7 +486,7 @@ class EwUser:
 				cursor = conn.cursor();
 
 				# Retrieve object
-				cursor.execute("SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} FROM users WHERE id_user = %s AND id_server = %s".format(
+				cursor.execute("SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} FROM users WHERE id_user = %s AND id_server = %s".format(
 					ewcfg.col_slimes,
 					ewcfg.col_slimelevel,
 					ewcfg.col_hunger,
@@ -517,6 +518,7 @@ class EwUser:
 					ewcfg.col_slime_donations,
 					ewcfg.col_poudrin_donations,
 					ewcfg.col_arrested,
+					ewcfg.col_splattered_slimes
 				), (
 					id_user,
 					id_server
@@ -556,6 +558,7 @@ class EwUser:
 					self.slime_donations = result[28]
 					self.poudrin_donations = result[29]
 					self.arrested = (result[30] == 1)
+					self.splattered_slimes = result[31]
 				else:
 					self.poi = ewcfg.poi_id_downtown
 					self.life_state = ewcfg.life_state_juvenile
@@ -611,7 +614,7 @@ class EwUser:
 			self.limit_fix();
 
 			# Save the object.
-			cursor.execute("REPLACE INTO users({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)".format(
+			cursor.execute("REPLACE INTO users({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)".format(
 				ewcfg.col_id_user,
 				ewcfg.col_id_server,
 				ewcfg.col_slimes,
@@ -646,6 +649,7 @@ class EwUser:
 				ewcfg.col_slime_donations,
 				ewcfg.col_poudrin_donations,
 				ewcfg.col_arrested,
+				ewcfg.col_splattered_slimes
 			), (
 				self.id_user,
 				self.id_server,
@@ -681,6 +685,7 @@ class EwUser:
 				self.slime_donations,
 				self.poudrin_donations,
 				(1 if self.arrested else 0),
+				self.splattered_slimes
 			))
 
 			conn.commit()

--- a/ewcfg.py
+++ b/ewcfg.py
@@ -357,7 +357,7 @@ hideout_by_faction = {
 }
 
 # Commands
-cmd_prefix = '/'
+cmd_prefix = '!'
 cmd_enlist = cmd_prefix + 'enlist'
 cmd_renounce = cmd_prefix + 'renounce'
 cmd_revive = cmd_prefix + 'revive'

--- a/ewcfg.py
+++ b/ewcfg.py
@@ -357,7 +357,7 @@ hideout_by_faction = {
 }
 
 # Commands
-cmd_prefix = '!'
+cmd_prefix = '/'
 cmd_enlist = cmd_prefix + 'enlist'
 cmd_renounce = cmd_prefix + 'renounce'
 cmd_revive = cmd_prefix + 'revive'
@@ -452,6 +452,7 @@ cmd_menu_alt2 = cmd_prefix + 'catalogue'
 cmd_order = cmd_prefix + 'order'
 cmd_annoint = cmd_prefix + 'annoint'
 cmd_annoint_alt1 = cmd_prefix + 'anoint'
+cmd_crush = cmd_prefix + 'crushpoudrin'
 cmd_disembody = cmd_prefix + 'disembody'
 cmd_war = cmd_prefix + 'war'
 cmd_toil = cmd_prefix + 'toil'
@@ -651,6 +652,9 @@ std_food_expir = 12 * 3600  # 12 hours
 farm_food_expir = 12 * 3600 * 4 # 2 days
 milled_food_expir = 12 * 3600 * 28 # 2 weeks
 
+# amount of slime you get from crushing a poudrin
+crush_slimes = 10000
+
 # minimum amount of slime needed to capture territory
 min_slime_to_cap = 50000
 
@@ -832,6 +836,9 @@ time_despawn = 60 * 180 # 3 hours
 
 # time for a player to be targeted by an enemy after entering a district
 time_enemyaggro = 3
+
+# time for a raid boss to target a player after moving to a new district
+time_raidbossaggro = 3
 
 # time for a raid boss to activate
 time_raidcountdown = 60
@@ -2623,7 +2630,7 @@ weapon_list = [
         str_trauma = "Simple yo-yo tricks caught even in their peripheral vision triggers intense PTSD flashbacks.",
         str_kill = "{name_player} performs a modified Kwyjibo, effortlessly nailing each step before killing their opponent just ahead of the dismount.",
         str_killdescriptor = "amazed",
-        str_damage = "{name_target} used {name_target}'s {hitzone} as a counterweight!!",
+        str_damage = "{name_player} used {name_target}'s {hitzone} as a counterweight!!",
         str_duel = "whhzzzzzz {name_player} and {name_target} practice trying to Walk the Dog for hours. It never clicks.",
 		str_description = "It's a yo-yo",
 		str_scalp = " It has a ball bearing hidden inside it. You can spin it like a fidget spinner.",
@@ -2808,10 +2815,10 @@ weapon_list = [
 		str_weaponmaster = "They are a rank {rank} master of the bass guitar.",
 		str_trauma_self = "There is a large concave dome in the side of your head.",
 		str_trauma = "There is a large concave dome in the side of their head.",
-		str_kill = "*CRASSHHH* {name_player} brings down the bass with righteous fury. Discordant notes play harshly as the bass trys its hardest to keep itself together. {emote_skull}",
+		str_kill = "*CRASSHHH.* {name_player} brings down the bass with righteous fury. Discordant notes play harshly as the bass trys its hardest to keep itself together. {emote_skull}",
 		str_killdescriptor = "smashed to pieces",
 		str_damage = "{name_target} is wacked across the {hitzone}!!",
-		str_duel = "**SMASHHH** {name_player} and {name_target} smash their bass together before admiring eachothers skillful basslines.",
+		str_duel = "**SMASHHH.** {name_player} and {name_target} smash their bass together before admiring eachothers skillful basslines.",
 		str_scalp = " If you listen closely, you can still hear the echoes of a sick bassline from yesteryear.",
 		fn_effect = wef_bass,
 		str_description = "It's a bass guitar. All of its strings are completely out of tune and rusted.",
@@ -2915,7 +2922,7 @@ def atf_molotovbreath(ctn = None):
 			ctn.crit = True
 			ctn.slimes_damage *= 2
 			
-def atf_raiderrifle(ctn = None):
+def atf_armcannon(ctn = None):
 	dmg = ctn.slimes_damage
 
 	aim = (random.randrange(20) + 1)
@@ -2997,15 +3004,15 @@ enemy_attack_type_list = [
 		fn_effect = atf_molotovbreath
 	),
 	EwAttackType( # 7
-		id_type = "sniper rifle",
+		id_type = "arm cannon",
 		str_crit = "**Critical hit!!** {name_target} has a clean hole shot through their chest by {name_enemy}'s bullet!",
 		str_miss = "**{name_enemy} missed their target!** The stray bullet cleaves right into the ground!",
 		str_trauma_self = "There's a deep bruising right in the middle of your forehead.",
 		str_trauma = "There's a deep bruising right in the middle of their forehead.",
-		str_kill = "{name_enemy} readies their crosshairs right for your head and pulls the trigger. The force from the bullet is so powerful that when it lodges itself into your skull, it rips your head right off in the process. {emote_skull}",
+		str_kill = "{name_enemy} readies their crosshair right for your head fires without hesitation. The force from the bullet is so powerful that when it lodges itself into your skull, it rips your head right off in the process. {emote_skull}",
 		str_killdescriptor = "sniped",
 		str_damage = "{name_target} has a bullet zoom right through their {hitzone}!!",
-		fn_effect = atf_raiderrifle
+		fn_effect = atf_armcannon
 	),
 ]
 
@@ -7395,7 +7402,7 @@ poi_list = [
 		role = "Assault Flats Beach Pier",
 		pvp = False,
 		is_subzone = True,
-		mother_district = poi_id_assaultflatsbeach_pier
+		mother_district = poi_id_assaultflatsbeach
 	),
 	EwPoi(  # Vagrant's Corner Pier
 		id_poi = poi_id_vagrantscorner_pier,
@@ -8255,7 +8262,8 @@ poi_list = [
 		channel="wreckington-outskirts",
 		role="Wreckington Outskirts",
 		pvp=True,
-		is_capturable=False
+		is_capturable=False,
+		is_outskirts=True
 	),
 	EwPoi(  # Outskirts - 2
 		id_poi=poi_id_cratersville_outskirts,
@@ -8270,7 +8278,8 @@ poi_list = [
 		channel="cratersville-outskirts",
 		role="Cratersville Outskirts",
 		pvp=True,
-		is_capturable=False
+		is_capturable=False,
+		is_outskirts=True
 	),
 	EwPoi(  # Outskirts - 3
 		id_poi=poi_id_oozegardens_outskirts,
@@ -8285,7 +8294,8 @@ poi_list = [
 		channel="ooze-gardens-outskirts",
 		role="Ooze Gardens Outskirts",
 		pvp=True,
-		is_capturable=False
+		is_capturable=False,
+		is_outskirts=True
 	),
 	EwPoi(  # Outskirts - 4
 		id_poi=poi_id_southsleezeborough_outskirts,
@@ -8300,7 +8310,8 @@ poi_list = [
 		channel="south-sleezeborough-outskirts",
 		role="South Sleezeborough Outskirts",
 		pvp=True,
-		is_capturable=False
+		is_capturable=False,
+		is_outskirts=True
 	),
 	EwPoi(  # Outskirts - 5
 		id_poi=poi_id_crookline_outskirts,
@@ -8315,7 +8326,8 @@ poi_list = [
 		channel="crookline-outskirts",
 		role="Crookline Outskirts",
 		pvp=True,
-		is_capturable=False
+		is_capturable=False,
+		is_outskirts=True
 	),
 	EwPoi(  # Outskirts - 6
 		id_poi=poi_id_dreadford_outskirts,
@@ -8330,7 +8342,8 @@ poi_list = [
 		channel="dreadford-outskirts",
 		role="Dreadford Outskirts",
 		pvp=True,
-		is_capturable=False
+		is_capturable=False,
+		is_outskirts=True
 	),
 	EwPoi(  # Outskirts - 7
 		id_poi=poi_id_jaywalkerplain_outskirts,
@@ -8345,7 +8358,8 @@ poi_list = [
 		channel="jaywalker-plain-outskirts",
 		role="Jaywalker Plain Outskirts",
 		pvp=True,
-		is_capturable=False
+		is_capturable=False,
+		is_outskirts=True
 	),
 	EwPoi(  # Outskirts - 8
 		id_poi=poi_id_westglocksbury_outskirts,
@@ -8360,7 +8374,8 @@ poi_list = [
 		channel="west-glocksbury-outskirts",
 		role="West Glocksbury Outskirts",
 		pvp=True,
-		is_capturable=False
+		is_capturable=False,
+		is_outskirts=True
 	),
 	EwPoi(  # Outskirts - 9
 		id_poi=poi_id_poloniumhill_outskirts,
@@ -8375,7 +8390,8 @@ poi_list = [
 		channel="polonium-hill-outskirts",
 		role="Polonium Hill Outskirts",
 		pvp=True,
-		is_capturable=False
+		is_capturable=False,
+		is_outskirts=True
 	),
 	EwPoi(  # Outskirts - 10
 		id_poi=poi_id_charcoalpark_outskirts,
@@ -8390,7 +8406,8 @@ poi_list = [
 		channel="charcoal-park-outskirts",
 		role="Charcoal Park Outskirts",
 		pvp=True,
-		is_capturable=False
+		is_capturable=False,
+		is_outskirts=True
 	),
 	EwPoi(  # Outskirts - 11
 		id_poi=poi_id_toxington_outskirts,
@@ -8405,7 +8422,8 @@ poi_list = [
 		channel="toxington-outskirts",
 		role="Toxington Outskirts",
 		pvp=True,
-		is_capturable=False
+		is_capturable=False,
+		is_outskirts=True
 	),
 	EwPoi(  # Outskirts - 12
 		id_poi=poi_id_astatineheights_outskirts,
@@ -8420,7 +8438,8 @@ poi_list = [
 		channel="astatine-heights-outskirts",
 		role="Astatine Heights Outskirts",
 		pvp=True,
-		is_capturable=False
+		is_capturable=False,
+		is_outskirts=True
 	),
 	EwPoi(  # Outskirts - 13
 		id_poi=poi_id_arsonbrook_outskirts,
@@ -8435,7 +8454,8 @@ poi_list = [
 		channel="arsonbrook-outskirts",
 		role="Arsonbrook Outskirts",
 		pvp=True,
-		is_capturable=False
+		is_capturable=False,
+		is_outskirts=True
 	),
 	EwPoi(  # Outskirts - 14
 		id_poi=poi_id_brawlden_outskirts,
@@ -8450,7 +8470,8 @@ poi_list = [
 		channel="brawlden-outskirts",
 		role="Brawlden Outskirts",
 		pvp=True,
-		is_capturable=False
+		is_capturable=False,
+		is_outskirts=True
 	),
 	EwPoi(  # Outskirts - 15
 		id_poi=poi_id_newnewyonkers_outskirts,
@@ -8465,7 +8486,8 @@ poi_list = [
 		channel="new-new-yonkers-outskirts",
 		role="New New Yonkers Outskirts",
 		pvp=True,
-		is_capturable=False
+		is_capturable=False,
+		is_outskirts=True
 	),
 	EwPoi(  # Outskirts - 16
 		id_poi=poi_id_assaultflatsbeach_outskirts,
@@ -8480,7 +8502,8 @@ poi_list = [
 		channel="assault-flats-beach-outskirts",
 		role="Assault Flats Beach Outskirts",
 		pvp=True,
-		is_capturable=False
+		is_capturable=False,
+		is_outskirts=True
 	),
 ]
 poi_list += ewdebug.debugpois
@@ -11457,7 +11480,7 @@ enemy_attacktype_tusks = 'tusks'
 enemy_attacktype_raiderscythe = 'scythe'
 enemy_attacktype_gunkshot = 'gunk shot'
 enemy_attacktype_molotovbreath = 'molotov breath'
-enemy_attacktype_raiderrifle = 'sniper rifle'
+enemy_attacktype_armcannon = 'arm cannon'
 
 # Enemy types
 # Common enemies
@@ -11513,6 +11536,15 @@ uncommon_enemies = [enemy_type_slimeadactyl, enemy_type_desertraider, enemy_type
 rare_enemies = [enemy_type_microslime]
 raid_bosses = [enemy_type_megaslime, enemy_type_slimeasaurusrex, enemy_type_greeneyesslimedragon, enemy_type_unnervingfightingoperator]
 
+# List of raid bosses sorted by their spawn rarity.
+raid_boss_tiers = {
+	"Micro": [enemy_type_megaslime],
+	"Monstrous": [enemy_type_slimeasaurusrex, enemy_type_unnervingfightingoperator],
+	"Mega": [enemy_type_greeneyesslimedragon],
+	# This can be left empty until we get more raid boss ideas.
+	#"Nega": [],
+}
+
 # Shorthand names the player can refer to enemies as.
 enemy_aliases = {
     enemy_type_juvie: ["juvie","greenman","lostjuvie"],
@@ -11542,14 +11574,14 @@ raid_boss_names = [
 # Enemy drop tables. Values are sorted by the chance to the drop an item, and then the minimum and maximum amount of times to drop that item.
 enemy_drop_tables = {
 	enemy_type_juvie: [{"poudrin": [50, 1, 2]}, {"pleb": [10, 1, 1]}, {"crop": [30, 1, 1]}, {"card": [20, 1, 1]}],
-	enemy_type_dinoslime: [{"poudrin": [100, 3, 4]}, {"pleb": [40, 1, 2]},  {"meat": [33, 1, 2]}],
-    enemy_type_slimeadactyl: [{"poudrin": [100, 4, 5]}, {"pleb": [40, 1, 2]}],
+	enemy_type_dinoslime: [{"poudrin": [100, 2, 4]}, {"pleb": [40, 1, 2]},  {"meat": [33, 1, 2]}],
+    enemy_type_slimeadactyl: [{"poudrin": [100, 3, 5]}, {"pleb": [40, 1, 2]}],
     enemy_type_microslime: [{"patrician": [100, 1, 1]}],
     enemy_type_desertraider: [{"poudrin": [100, 1, 2]}, {"pleb": [100, 1, 1]},  {"crop": [50, 3, 6]}],
 	enemy_type_mammoslime: [{"poudrin": [50, 1, 2]},  {"patrician": [50, 1, 2]}],
-    enemy_type_megaslime: [{"poudrin": [100, 6, 10]}, {"pleb": [100, 2, 4]}, {"patrician": [33, 1, 1]}],
-	enemy_type_slimeasaurusrex: [{"poudrin": [100, 8, 10]}, {"pleb": [75, 3, 3]}, {"patrician": [50, 1, 1]},  {"meat": [100, 2, 3]}],
-	enemy_type_greeneyesslimedragon: [{"poudrin": [100, 8, 12]}, {"patrician": [100, 1, 2]}],
+    enemy_type_megaslime: [{"poudrin": [100, 4, 8]}, {"pleb": [100, 1, 3]}, {"patrician": [33, 1, 1]}],
+	enemy_type_slimeasaurusrex: [{"poudrin": [100, 8, 15]}, {"pleb": [75, 3, 3]}, {"patrician": [50, 1, 2]},  {"meat": [100, 3, 4]}],
+	enemy_type_greeneyesslimedragon: [{"poudrin": [100, 15, 20]}, {"patrician": [100, 2, 4]}],
 	enemy_type_unnervingfightingoperator: [{"poudrin": [100, 1, 1]}, {"crop": [100, 1, 1]}, {"meat": [100, 1, 1]}, {"card": [100, 1, 1]}]
 }
 

--- a/ewdistrict.py
+++ b/ewdistrict.py
@@ -116,7 +116,7 @@ class EwDistrict:
 		for neighbor_id in neighbors:
 			neighbor_poi = ewcfg.id_to_poi.get(neighbor_id)
 			neighbor_data = EwDistrict(id_server = self.id_server, district = neighbor_id)
-			if neighbor_data.controlling_faction != self.controlling_faction and not neighbor_poi.is_subzone:
+			if neighbor_data.controlling_faction != self.controlling_faction and not neighbor_poi.is_subzone and not neighbor_poi.is_outskirts:
 				return False
 		return True
 

--- a/ewhunting.py
+++ b/ewhunting.py
@@ -758,33 +758,29 @@ async def summon_enemy(cmd):
 async def enemy_perform_action(id_server):
 	
 	despawn_timenow = int(time.time()) - ewcfg.time_despawn
-	
-	print("TEST")
 
-	enemydata = ewutils.execute_sql_query(
-	  "SELECT {id_enemy} FROM users, enemies WHERE ((users.poi = enemies.poi AND (users.life_state != %s OR users.life_state != %s) AND users.id_server = '{id_server}') OR (enemies.enemytype IN %s) OR (enemies.life_state = %s OR enemies.lifetime < %s)) AND enemies.id_server = '{id_server}'".format(
-		  id_enemy=ewcfg.col_id_enemy,
-		  id_server=id_server
-	  ), (
-		  ewcfg.life_state_corpse,
-		  ewcfg.life_state_kingpin,
-		  ewcfg.raid_bosses,
-		  ewcfg.enemy_lifestate_dead,
-		  despawn_timenow
-	  ))
-	# enemydata = ewutils.execute_sql_query("SELECT {id_enemy} FROM enemies WHERE id_server = %s".format(
-	#     id_enemy = ewcfg.col_id_enemys
-	# ),(
-	#     id_server,
-	# ))
+	# enemydata = ewutils.execute_sql_query(
+	#   "SELECT {id_enemy} FROM users, enemies WHERE ((users.poi = enemies.poi AND (users.life_state != %s OR users.life_state != %s) AND users.id_server = '{id_server}') OR (enemies.enemytype IN %s) OR (enemies.life_state = %s OR enemies.lifetime < %s)) AND enemies.id_server = '{id_server}'".format(
+	# 	  id_enemy=ewcfg.col_id_enemy,
+	# 	  id_server=id_server
+	#   ), (
+	# 	  ewcfg.life_state_corpse,
+	# 	  ewcfg.life_state_kingpin,
+	# 	  ewcfg.raid_bosses,
+	# 	  ewcfg.enemy_lifestate_dead,
+	# 	  despawn_timenow
+	#   ))
+	enemydata = ewutils.execute_sql_query("SELECT {id_enemy} FROM enemies WHERE id_server = %s".format(
+		id_enemy = ewcfg.col_id_enemy
+	),(
+		id_server,
+	))
 
 	# Remove duplicates from SQL query
-	enemydata = list(dict.fromkeys(enemydata))
-	print("ENEMYDATA: {}".format(enemydata))
+	#enemydata = set(enemydata)
 
 	for row in enemydata:
 		enemy = EwEnemy(id_enemy=row[0], id_server=id_server)
-		#print(enemy.enemytype)
 
 		# If an enemy is marked for death or has been alive too long, delete it
 		if enemy.life_state == ewcfg.enemy_lifestate_dead or (enemy.lifetime < despawn_timenow):

--- a/ewhunting.py
+++ b/ewhunting.py
@@ -20,1551 +20,1554 @@ from ewslimeoid import EwSlimeoid
 """ Enemy data model for database persistence """
 
 class EwEnemy:
-    id_enemy = 0
-    id_server = ""
+	id_enemy = 0
+	id_server = ""
 
-    # The amount of slime an enemy has
-    slimes = 0
+	# The amount of slime an enemy has
+	slimes = 0
 
-    # The total amount of damage an enemy has sustained throughout its lifetime
-    totaldamage = 0
+	# The total amount of damage an enemy has sustained throughout its lifetime
+	totaldamage = 0
 
-    # The type of AI the enemy uses to select which players to attack
-    ai = ""
+	# The type of AI the enemy uses to select which players to attack
+	ai = ""
 
-    # The name of enemy shown in responses
-    display_name = ""
+	# The name of enemy shown in responses
+	display_name = ""
 
-    # Used to help identify enemies of the same type in a district
-    identifier = ""
+	# Used to help identify enemies of the same type in a district
+	identifier = ""
 
-    # An enemy's level, which determines how much damage it does
-    level = 0
+	# An enemy's level, which determines how much damage it does
+	level = 0
 
-    # An enemy's location
-    poi = ""
+	# An enemy's location
+	poi = ""
 
-    # Life state 0 = Dead, pending for deletion when it tries its next attack / action
-    # Life state 1 = Alive / Activated raid boss
-    # Life state 2 = Raid boss pending activation
-    life_state = 0
+	# Life state 0 = Dead, pending for deletion when it tries its next attack / action
+	# Life state 1 = Alive / Activated raid boss
+	# Life state 2 = Raid boss pending activation
+	life_state = 0
 
-    # Used to determine how much slime an enemy gets, what AI it uses, as well as what weapon it uses.
-    enemytype = ""
+	# Used to determine how much slime an enemy gets, what AI it uses, as well as what weapon it uses.
+	enemytype = ""
 
-    # The 'weapon' of an enemy
-    attacktype = ""
+	# The 'weapon' of an enemy
+	attacktype = ""
 
-    # An enemy's bleed storage
-    bleed_storage = 0
+	# An enemy's bleed storage
+	bleed_storage = 0
 
-    # Used for determining when a raid boss should be able to move between districts
-    time_lastenter = 0
+	# Used for determining when a raid boss should be able to move between districts
+	time_lastenter = 0
 
-    # Used to determine how much slime an enemy started out with to create a 'health bar' ( current slime / initial slime )
-    initialslimes = 0
+	# Used to determine how much slime an enemy started out with to create a 'health bar' ( current slime / initial slime )
+	initialslimes = 0
 
-    # Enemies despawn when this number reaches 10800 (3 hours)
-    lifetime = 0
+	# Enemies despawn when this number reaches 10800 (3 hours)
+	lifetime = 0
 
-    # Used by the 'defender' AI to determine who it should retaliate against
-    id_target = ""
+	# Used by the 'defender' AI to determine who it should retaliate against
+	id_target = ""
 
-    # Used by raid bosses to determine when they should activate
-    raidtimer = 0
-    
-    # Determines if an enemy should use its rare variant or not
-    rare_status = 0
+	# Used by raid bosses to determine when they should activate
+	raidtimer = 0
+	
+	# Determines if an enemy should use its rare variant or not
+	rare_status = 0
 
-    """ Load the enemy data from the database. """
+	""" Load the enemy data from the database. """
 
-    def __init__(self, id_enemy=None, id_server=None, enemytype=None):
-        query_suffix = ""
+	def __init__(self, id_enemy=None, id_server=None, enemytype=None):
+		query_suffix = ""
 
-        if id_enemy != None:
-            query_suffix = " WHERE id_enemy = '{}'".format(id_enemy)
-        else:
+		if id_enemy != None:
+			query_suffix = " WHERE id_enemy = '{}'".format(id_enemy)
+		else:
 
-            if id_server != None:
-                query_suffix = " WHERE id_server = '{}'".format(id_server)
-                if enemytype != None:
-                    query_suffix += " AND enemytype = '{}'".format(enemytype)
+			if id_server != None:
+				query_suffix = " WHERE id_server = '{}'".format(id_server)
+				if enemytype != None:
+					query_suffix += " AND enemytype = '{}'".format(enemytype)
 
-        if query_suffix != "":
-            try:
-                conn_info = ewutils.databaseConnect()
-                conn = conn_info.get('conn')
-                cursor = conn.cursor();
+		if query_suffix != "":
+			try:
+				conn_info = ewutils.databaseConnect()
+				conn = conn_info.get('conn')
+				cursor = conn.cursor();
 
-                # Retrieve object
-                cursor.execute(
-                    "SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} FROM enemies{}".format(
-                        ewcfg.col_id_enemy,
-                        ewcfg.col_id_server,
-                        ewcfg.col_enemy_slimes,
-                        ewcfg.col_enemy_totaldamage,
-                        ewcfg.col_enemy_ai,
-                        ewcfg.col_enemy_type,
-                        ewcfg.col_enemy_attacktype,
-                        ewcfg.col_enemy_display_name,
-                        ewcfg.col_enemy_identifier,
-                        ewcfg.col_enemy_level,
-                        ewcfg.col_enemy_poi,
-                        ewcfg.col_enemy_life_state,
-                        ewcfg.col_enemy_bleed_storage,
-                        ewcfg.col_enemy_time_lastenter,
-                        ewcfg.col_enemy_initialslimes,
-                        ewcfg.col_enemy_lifetime,
-                        ewcfg.col_enemy_id_target,
-                        ewcfg.col_enemy_raidtimer,
-                        ewcfg.col_enemy_rare_status,
-                        query_suffix
-                    ))
-                result = cursor.fetchone();
+				# Retrieve object
+				cursor.execute(
+					"SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} FROM enemies{}".format(
+						ewcfg.col_id_enemy,
+						ewcfg.col_id_server,
+						ewcfg.col_enemy_slimes,
+						ewcfg.col_enemy_totaldamage,
+						ewcfg.col_enemy_ai,
+						ewcfg.col_enemy_type,
+						ewcfg.col_enemy_attacktype,
+						ewcfg.col_enemy_display_name,
+						ewcfg.col_enemy_identifier,
+						ewcfg.col_enemy_level,
+						ewcfg.col_enemy_poi,
+						ewcfg.col_enemy_life_state,
+						ewcfg.col_enemy_bleed_storage,
+						ewcfg.col_enemy_time_lastenter,
+						ewcfg.col_enemy_initialslimes,
+						ewcfg.col_enemy_lifetime,
+						ewcfg.col_enemy_id_target,
+						ewcfg.col_enemy_raidtimer,
+						ewcfg.col_enemy_rare_status,
+						query_suffix
+					))
+				result = cursor.fetchone();
 
-                if result != None:
-                    # Record found: apply the data to this object.
-                    self.id_enemy = result[0]
-                    self.id_server = result[1]
-                    self.slimes = result[2]
-                    self.totaldamage = result[3]
-                    self.ai = result[4]
-                    self.enemytype = result[5]
-                    self.attacktype = result[6]
-                    self.display_name = result[7]
-                    self.identifier = result[8]
-                    self.level = result[9]
-                    self.poi = result[10]
-                    self.life_state = result[11]
-                    self.bleed_storage = result[12]
-                    self.time_lastenter = result[13]
-                    self.initialslimes = result[14]
-                    self.lifetime = result[15]
-                    self.id_target = result[16]
-                    self.raidtimer = result[17]
-                    self.rare_status = result[18]
+				if result != None:
+					# Record found: apply the data to this object.
+					self.id_enemy = result[0]
+					self.id_server = result[1]
+					self.slimes = result[2]
+					self.totaldamage = result[3]
+					self.ai = result[4]
+					self.enemytype = result[5]
+					self.attacktype = result[6]
+					self.display_name = result[7]
+					self.identifier = result[8]
+					self.level = result[9]
+					self.poi = result[10]
+					self.life_state = result[11]
+					self.bleed_storage = result[12]
+					self.time_lastenter = result[13]
+					self.initialslimes = result[14]
+					self.lifetime = result[15]
+					self.id_target = result[16]
+					self.raidtimer = result[17]
+					self.rare_status = result[18]
 
-            finally:
-                # Clean up the database handles.
-                cursor.close()
-                ewutils.databaseClose(conn_info)
+			finally:
+				# Clean up the database handles.
+				cursor.close()
+				ewutils.databaseClose(conn_info)
 
-    """ Save enemy data object to the database. """
+	""" Save enemy data object to the database. """
 
-    def persist(self):
-        try:
-            conn_info = ewutils.databaseConnect()
-            conn = conn_info.get('conn')
-            cursor = conn.cursor();
+	def persist(self):
+		try:
+			conn_info = ewutils.databaseConnect()
+			conn = conn_info.get('conn')
+			cursor = conn.cursor();
 
-            # Save the object.
-            cursor.execute(
-                "REPLACE INTO enemies({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)".format(
-                    ewcfg.col_id_enemy,
-                    ewcfg.col_id_server,
-                    ewcfg.col_enemy_slimes,
-                    ewcfg.col_enemy_totaldamage,
-                    ewcfg.col_enemy_ai,
-                    ewcfg.col_enemy_type,
-                    ewcfg.col_enemy_attacktype,
-                    ewcfg.col_enemy_display_name,
-                    ewcfg.col_enemy_identifier,
-                    ewcfg.col_enemy_level,
-                    ewcfg.col_enemy_poi,
-                    ewcfg.col_enemy_life_state,
-                    ewcfg.col_enemy_bleed_storage,
-                    ewcfg.col_enemy_time_lastenter,
-                    ewcfg.col_enemy_initialslimes,
-                    ewcfg.col_enemy_lifetime,
-                    ewcfg.col_enemy_id_target,
-                    ewcfg.col_enemy_raidtimer,
-                    ewcfg.col_enemy_rare_status,
-                ), (
-                    self.id_enemy,
-                    self.id_server,
-                    self.slimes,
-                    self.totaldamage,
-                    self.ai,
-                    self.enemytype,
-                    self.attacktype,
-                    self.display_name,
-                    self.identifier,
-                    self.level,
-                    self.poi,
-                    self.life_state,
-                    self.bleed_storage,
-                    self.time_lastenter,
-                    self.initialslimes,
-                    self.lifetime,
-                    self.id_target,
-                    self.raidtimer,
-                    self.rare_status,
-                ))
+			# Save the object.
+			cursor.execute(
+				"REPLACE INTO enemies({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)".format(
+					ewcfg.col_id_enemy,
+					ewcfg.col_id_server,
+					ewcfg.col_enemy_slimes,
+					ewcfg.col_enemy_totaldamage,
+					ewcfg.col_enemy_ai,
+					ewcfg.col_enemy_type,
+					ewcfg.col_enemy_attacktype,
+					ewcfg.col_enemy_display_name,
+					ewcfg.col_enemy_identifier,
+					ewcfg.col_enemy_level,
+					ewcfg.col_enemy_poi,
+					ewcfg.col_enemy_life_state,
+					ewcfg.col_enemy_bleed_storage,
+					ewcfg.col_enemy_time_lastenter,
+					ewcfg.col_enemy_initialslimes,
+					ewcfg.col_enemy_lifetime,
+					ewcfg.col_enemy_id_target,
+					ewcfg.col_enemy_raidtimer,
+					ewcfg.col_enemy_rare_status,
+				), (
+					self.id_enemy,
+					self.id_server,
+					self.slimes,
+					self.totaldamage,
+					self.ai,
+					self.enemytype,
+					self.attacktype,
+					self.display_name,
+					self.identifier,
+					self.level,
+					self.poi,
+					self.life_state,
+					self.bleed_storage,
+					self.time_lastenter,
+					self.initialslimes,
+					self.lifetime,
+					self.id_target,
+					self.raidtimer,
+					self.rare_status,
+				))
 
-            conn.commit()
-        finally:
-            # Clean up the database handles.
-            cursor.close()
-            ewutils.databaseClose(conn_info)
+			conn.commit()
+		finally:
+			# Clean up the database handles.
+			cursor.close()
+			ewutils.databaseClose(conn_info)
 
-    # Function that enemies use to attack or otherwise interact with players.
-    async def kill(self):
+	# Function that enemies use to attack or otherwise interact with players.
+	async def kill(self):
 
-        client = ewutils.get_client()
+		client = ewutils.get_client()
 
-        last_messages = []
-        should_post_resp_cont = True
+		last_messages = []
+		should_post_resp_cont = True
 
-        enemy_data = self
+		enemy_data = self
 
-        time_now = int(time.time())
-        resp_cont = ewutils.EwResponseContainer(id_server=enemy_data.id_server)
-        district_data = EwDistrict(district=enemy_data.poi, id_server=enemy_data.id_server)
-        market_data = EwMarket(id_server=enemy_data.id_server)
-        ch_name = ewcfg.id_to_poi.get(enemy_data.poi).channel
+		time_now = int(time.time())
+		resp_cont = ewutils.EwResponseContainer(id_server=enemy_data.id_server)
+		district_data = EwDistrict(district=enemy_data.poi, id_server=enemy_data.id_server)
+		market_data = EwMarket(id_server=enemy_data.id_server)
+		ch_name = ewcfg.id_to_poi.get(enemy_data.poi).channel
 
-        target_data = None
-        target_player = None
-        target_slimeoid = None
+		target_data = None
+		target_player = None
+		target_slimeoid = None
 
-        used_attacktype = None
+		used_attacktype = None
 
-        if enemy_data.attacktype != ewcfg.enemy_attacktype_unarmed:
-            used_attacktype = ewcfg.attack_type_map.get(enemy_data.attacktype)
-        else:
-            used_attacktype = ewcfg.enemy_attacktype_unarmed
+		if enemy_data.attacktype != ewcfg.enemy_attacktype_unarmed:
+			used_attacktype = ewcfg.attack_type_map.get(enemy_data.attacktype)
+		else:
+			used_attacktype = ewcfg.enemy_attacktype_unarmed
 
-        # Get target's info based on its AI.
+		# Get target's info based on its AI.
 
-        if enemy_data.ai == ewcfg.enemy_ai_coward:
-            users = ewutils.execute_sql_query(
-                "SELECT {id_user}, {life_state} FROM users WHERE {poi} = %s AND {id_server} = %s AND NOT {life_state} = {life_state_corpse}".format(
-                    id_user=ewcfg.col_id_user,
-                    life_state=ewcfg.col_life_state,
-                    poi=ewcfg.col_poi,
-                    id_server=ewcfg.col_id_server,
-                    life_state_corpse=ewcfg.life_state_corpse
-                ), (
-                    enemy_data.poi,
-                    enemy_data.id_server
-                ))
-            if len(users) > 0:
-                if random.randrange(100) > 92:
-                    response = random.choice(ewcfg.coward_responses)
-                    response = response.format(enemy_data.display_name, enemy_data.display_name)
-                    resp_cont.add_channel_response(ch_name, response)
-        else:
-            target_data = get_target_by_ai(enemy_data)
+		if enemy_data.ai == ewcfg.enemy_ai_coward:
+			users = ewutils.execute_sql_query(
+				"SELECT {id_user}, {life_state} FROM users WHERE {poi} = %s AND {id_server} = %s AND NOT ({life_state} = {life_state_corpse} OR {life_state} = {life_state_kingpin})".format(
+					id_user=ewcfg.col_id_user,
+					life_state=ewcfg.col_life_state,
+					poi=ewcfg.col_poi,
+					id_server=ewcfg.col_id_server,
+					life_state_corpse=ewcfg.life_state_corpse,
+					life_state_kingpin=ewcfg.life_state_kingpin,
+				), (
+					enemy_data.poi,
+					enemy_data.id_server
+				))
+			if len(users) > 0:
+				if random.randrange(100) > 92:
+					response = random.choice(ewcfg.coward_responses)
+					response = response.format(enemy_data.display_name, enemy_data.display_name)
+					resp_cont.add_channel_response(ch_name, response)
+		else:
+			target_data = get_target_by_ai(enemy_data)
 
-        if check_raidboss_countdown(enemy_data) and enemy_data.life_state == ewcfg.enemy_lifestate_unactivated:
-            # Raid boss has activated!
-            response = "*The ground quakes beneath your feet as slime begins to pool into one hulking, solidified mass...*" \
-                       "\n{} **{} has arrvied! It's level {} and has {} slime!** {}\n".format(
-                ewcfg.emote_megaslime,
-                enemy_data.display_name,
-                enemy_data.level,
-                enemy_data.slimes,
-                ewcfg.emote_megaslime
-            )
-            resp_cont.add_channel_response(ch_name, response)
+		if check_raidboss_countdown(enemy_data) and enemy_data.life_state == ewcfg.enemy_lifestate_unactivated:
+			# Raid boss has activated!
+			response = "*The ground quakes beneath your feet as slime begins to pool into one hulking, solidified mass...*" \
+					   "\n{} **{} has arrvied! It's level {} and has {} slime!** {}\n".format(
+				ewcfg.emote_megaslime,
+				enemy_data.display_name,
+				enemy_data.level,
+				enemy_data.slimes,
+				ewcfg.emote_megaslime
+			)
+			resp_cont.add_channel_response(ch_name, response)
 
-            enemy_data.life_state = ewcfg.enemy_lifestate_alive
-            enemy_data.time_lastenter = time_now
-            enemy_data.persist()
+			enemy_data.life_state = ewcfg.enemy_lifestate_alive
+			enemy_data.time_lastenter = time_now
+			enemy_data.persist()
 
-            target_data = None
+			target_data = None
 
-        elif check_raidboss_countdown(enemy_data) and enemy_data.life_state == ewcfg.enemy_lifestate_alive:
-            # Raid boss attacks.
-            pass
+		elif check_raidboss_countdown(enemy_data) and enemy_data.life_state == ewcfg.enemy_lifestate_alive:
+			# Raid boss attacks.
+			pass
 
-        # If a raid boss is currently counting down, delete the previous countdown message to reduce visual clutter.
-        elif check_raidboss_countdown(enemy_data) == False:
+		# If a raid boss is currently counting down, delete the previous countdown message to reduce visual clutter.
+		elif check_raidboss_countdown(enemy_data) == False:
 
-            target_data = None
+			target_data = None
 
-            while check_raidboss_countdown(enemy_data) == False:
-                timer = (enemy_data.raidtimer - (int(time.time())) + ewcfg.time_raidcountdown)
+			timer = (enemy_data.raidtimer - (int(time.time())) + ewcfg.time_raidcountdown)
 
-                if timer < ewcfg.enemy_attack_tick_length and timer != 0:
-                    timer = ewcfg.enemy_attack_tick_length
+			if timer < ewcfg.enemy_attack_tick_length and timer != 0:
+				timer = ewcfg.enemy_attack_tick_length
 
-                countdown_response = "A sinister presence is lurking. Time remaining: {} seconds...".format(timer)
-                resp_cont.add_channel_response(ch_name, countdown_response)
+			countdown_response = "A sinister presence is lurking. Time remaining: {} seconds...".format(timer)
+			resp_cont.add_channel_response(ch_name, countdown_response)
 
-                try:
-                    await asyncio.sleep(ewcfg.enemy_attack_tick_length)
-                    await client.delete_message(last_messages[len(last_messages)-1])
-                except:
-                    pass
+			#TODO: Edit the countdown message instead of deleting and reposting
+			last_messages = await resp_cont.post()
+			asyncio.ensure_future(ewutils.delete_last_message(client, last_messages, ewcfg.enemy_attack_tick_length))
+			
+			# Don't post resp_cont a second time while the countdown is going on.
+			should_post_resp_cont = False
 
-                last_messages = await resp_cont.post()
+		if target_data != None:
 
-            # Once it exits the loop, delete the final countdown message
-            try:
-                await asyncio.sleep(ewcfg.enemy_attack_tick_length)
-                await client.delete_message(last_messages[len(last_messages) - 1])
-            except:
-                pass
+			target_player = EwPlayer(id_user=target_data.id_user)
+			target_slimeoid = EwSlimeoid(id_user=target_data.id_user)
 
-            # Don't make an attempt to post resp_cont, since it should be emptied out after the loop exit
-            should_post_resp_cont = False
+			server = client.get_server(target_data.id_server)
+			# server = discord.Server(id=target_data.id_server)
+			# print(target_data.id_server)
+			# channel = discord.utils.get(server.channels, name=ch_name)
 
+			# print(server)
 
-        if target_data != None:
-
-            target_player = EwPlayer(id_user=target_data.id_user)
-            target_slimeoid = EwSlimeoid(id_user=target_data.id_user)
-
-            server = client.get_server(target_data.id_server)
-            # server = discord.Server(id=target_data.id_server)
-            # print(target_data.id_server)
-            # channel = discord.utils.get(server.channels, name=ch_name)
-
-            # print(server)
-
-            # member = discord.utils.get(channel.server.members, name=target_player.display_name)
-            # print(member)
+			# member = discord.utils.get(channel.server.members, name=target_player.display_name)
+			# print(member)
 					
 
-            target_mutations = target_data.get_mutations()
+			target_mutations = target_data.get_mutations()
 
-            miss = False
-            crit = False
-            backfire = False
-            strikes = 0
+			miss = False
+			crit = False
+			backfire = False
+			strikes = 0
 
-            # maybe enemies COULD have weapon skills? could punishes players who die to the same enemy without mining up beforehand
-            # slimes_damage = int((slimes_spent * 4) * (100 + (user_data.weaponskill * 10)) / 100.0)
+			# maybe enemies COULD have weapon skills? could punishes players who die to the same enemy without mining up beforehand
+			# slimes_damage = int((slimes_spent * 4) * (100 + (user_data.weaponskill * 10)) / 100.0)
 
-            # since enemies dont use up slime or hunger, this is only used for damage calculation
-            slimes_spent = int(ewutils.slime_bylevel(enemy_data.level) / 20 * ewcfg.enemy_attack_tick_length / 2)
+			# since enemies dont use up slime or hunger, this is only used for damage calculation
+			slimes_spent = int(ewutils.slime_bylevel(enemy_data.level) / 20 * ewcfg.enemy_attack_tick_length / 2)
 
-            slimes_damage = int(slimes_spent * 4)
+			slimes_damage = int(slimes_spent * 4)
 
-            if used_attacktype == ewcfg.enemy_attacktype_unarmed:
-                slimes_damage /= 2  # specific to juvies
-            if enemy_data.enemytype == ewcfg.enemy_type_microslime:
-                slimes_damage *= 20  # specific to microslime
+			if used_attacktype == ewcfg.enemy_attacktype_unarmed:
+				slimes_damage /= 2  # specific to juvies
+			if enemy_data.enemytype == ewcfg.enemy_type_microslime:
+				slimes_damage *= 20  # specific to microslime
 
-            # Organic Fursuit
-            if ewcfg.mutation_id_organicfursuit in target_mutations and (
-                    (market_data.day % 31 == 0 and market_data.clock >= 20)
-                    or (market_data.day % 31 == 1 and market_data.clock < 6)
-            ):
-                slimes_damage *= 0.1
+			# Organic Fursuit
+			if ewcfg.mutation_id_organicfursuit in target_mutations and (
+					(market_data.day % 31 == 0 and market_data.clock >= 20)
+					or (market_data.day % 31 == 1 and market_data.clock < 6)
+			):
+				slimes_damage *= 0.1
 
-            # Fat chance
-            if ewcfg.mutation_id_fatchance in target_mutations and target_data.hunger / target_data.get_hunger_max() > 0.5:
-                slimes_damage *= 0.75
+			# Fat chance
+			if ewcfg.mutation_id_fatchance in target_mutations and target_data.hunger / target_data.get_hunger_max() > 0.5:
+				slimes_damage *= 0.75
 
-            slimes_dropped = target_data.totaldamage + target_data.slimes
+			slimes_dropped = target_data.totaldamage + target_data.slimes
 
-            target_iskillers = target_data.life_state == ewcfg.life_state_enlisted and target_data.faction == ewcfg.faction_killers
-            target_isrowdys = target_data.life_state == ewcfg.life_state_enlisted and target_data.faction == ewcfg.faction_rowdys
-            target_isslimecorp = target_data.life_state in [ewcfg.life_state_lucky, ewcfg.life_state_executive]
-            target_isjuvie = target_data.life_state == ewcfg.life_state_juvenile
-            target_isnotdead = target_data.life_state != ewcfg.life_state_corpse
+			target_iskillers = target_data.life_state == ewcfg.life_state_enlisted and target_data.faction == ewcfg.faction_killers
+			target_isrowdys = target_data.life_state == ewcfg.life_state_enlisted and target_data.faction == ewcfg.faction_rowdys
+			target_isslimecorp = target_data.life_state in [ewcfg.life_state_lucky, ewcfg.life_state_executive]
+			target_isjuvie = target_data.life_state == ewcfg.life_state_juvenile
+			target_isnotdead = target_data.life_state != ewcfg.life_state_corpse
 
-            if target_data.life_state == ewcfg.life_state_kingpin:
-                # Disallow killing generals.
-                response = "The {} tries to attack the kingpin, but is taken aback by the sheer girth of their slime.".format(enemy_data.display_name)
-                resp_cont.add_channel_response(ch_name, response)
+			if target_data.life_state == ewcfg.life_state_kingpin:
+				# Disallow killing generals.
+				response = "The {} tries to attack the kingpin, but is taken aback by the sheer girth of their slime.".format(enemy_data.display_name)
+				resp_cont.add_channel_response(ch_name, response)
 
-            elif (time_now - target_data.time_lastrevive) < ewcfg.invuln_onrevive:
-                # User is currently invulnerable.
-                response = "The {} tries to attack {}, but they have died too recently and are immune.".format(
-                    enemy_data.display_name,
-                    target_player.display_name)
-                resp_cont.add_channel_response(ch_name, response)
+			elif (time_now - target_data.time_lastrevive) < ewcfg.invuln_onrevive:
+				# User is currently invulnerable.
+				response = "The {} tries to attack {}, but they have died too recently and are immune.".format(
+					enemy_data.display_name,
+					target_player.display_name)
+				resp_cont.add_channel_response(ch_name, response)
 
-            # enemies dont fuck with ghosts, ghosts dont fuck with enemies.
-            elif (target_iskillers or target_isrowdys or target_isjuvie or target_isslimecorp) and (target_isnotdead):
-                was_killed = False
-                was_hurt = False
+			# enemies dont fuck with ghosts, ghosts dont fuck with enemies.
+			elif (target_iskillers or target_isrowdys or target_isjuvie or target_isslimecorp) and (target_isnotdead):
+				was_killed = False
+				was_hurt = False
 
-                if target_data.life_state in [ewcfg.life_state_enlisted, ewcfg.life_state_juvenile, ewcfg.life_state_lucky, ewcfg.life_state_executive]:
+				if target_data.life_state in [ewcfg.life_state_enlisted, ewcfg.life_state_juvenile, ewcfg.life_state_lucky, ewcfg.life_state_executive]:
 
-                    # If a target is being attacked by an enemy with the defender ai, check to make sure it can be hit.
-                    if (enemy_data.ai == ewcfg.enemy_ai_defender) and (ewutils.check_defender_targets(target_data, enemy_data) == False):
-                        return
-                    else:
-                        # Target can be hurt by enemies.
-                        was_hurt = True
+					# If a target is being attacked by an enemy with the defender ai, check to make sure it can be hit.
+					if (enemy_data.ai == ewcfg.enemy_ai_defender) and (ewutils.check_defender_targets(target_data, enemy_data) == False):
+						return
+					else:
+						# Target can be hurt by enemies.
+						was_hurt = True
 
-                if was_hurt:
-                    # Weaponized flavor text.
-                    randombodypart = ewcfg.hitzone_list[random.randrange(len(ewcfg.hitzone_list))]
+				if was_hurt:
+					# Weaponized flavor text.
+					randombodypart = ewcfg.hitzone_list[random.randrange(len(ewcfg.hitzone_list))]
 
-                    # Attacking-type-specific adjustments
-                    if used_attacktype != ewcfg.enemy_attacktype_unarmed and used_attacktype.fn_effect != None:
-                        # Build effect container
-                        ctn = EwEnemyEffectContainer(
-                            miss=miss,
-                            backfire=backfire,
-                            crit=crit,
-                            slimes_damage=slimes_damage,
-                            enemy_data=enemy_data,
-                            target_data=target_data
-                        )
+					# Attacking-type-specific adjustments
+					if used_attacktype != ewcfg.enemy_attacktype_unarmed and used_attacktype.fn_effect != None:
+						# Build effect container
+						ctn = EwEnemyEffectContainer(
+							miss=miss,
+							backfire=backfire,
+							crit=crit,
+							slimes_damage=slimes_damage,
+							enemy_data=enemy_data,
+							target_data=target_data
+						)
 
-                        # Make adjustments
-                        used_attacktype.fn_effect(ctn)
+						# Make adjustments
+						used_attacktype.fn_effect(ctn)
 
-                        # Apply effects for non-reference values
-                        miss = ctn.miss
-                        backfire = ctn.backfire
-                        crit = ctn.crit
-                        slimes_damage = ctn.slimes_damage
-                        strikes = ctn.strikes
+						# Apply effects for non-reference values
+						miss = ctn.miss
+						backfire = ctn.backfire
+						crit = ctn.crit
+						slimes_damage = ctn.slimes_damage
+						strikes = ctn.strikes
 
-                    # can't hit lucky lucy
-                    if target_data.life_state == ewcfg.life_state_lucky:
-                        miss = True
+					# can't hit lucky lucy
+					if target_data.life_state == ewcfg.life_state_lucky:
+						miss = True
 
-                    if miss:
-                        slimes_damage = 0
+					if miss:
+						slimes_damage = 0
 
-                    enemy_data.persist()
-                    target_data = EwUser(id_user = target_data.id_user, id_server = target_data.id_server)
+					enemy_data.persist()
+					target_data = EwUser(id_user = target_data.id_user, id_server = target_data.id_server)
 
 
-                    if slimes_damage >= target_data.slimes - target_data.bleed_storage:
-                        was_killed = True
-                        slimes_damage = max(target_data.slimes - target_data.bleed_storage, 0)
+					if slimes_damage >= target_data.slimes - target_data.bleed_storage:
+						was_killed = True
+						slimes_damage = max(target_data.slimes - target_data.bleed_storage, 0)
 
-                    sewer_data = EwDistrict(district=ewcfg.poi_id_thesewers, id_server=enemy_data.id_server)
+					sewer_data = EwDistrict(district=ewcfg.poi_id_thesewers, id_server=enemy_data.id_server)
 
-                    # move around slime as a result of the shot
-                    if target_isjuvie:
-                        slimes_drained = int(3 * slimes_damage / 4)  # 3/4
-                    else:
-                        slimes_drained = 0
+					# move around slime as a result of the shot
+					if target_isjuvie:
+						slimes_drained = int(3 * slimes_damage / 4)  # 3/4
+					else:
+						slimes_drained = 0
 
-                    damage = str(slimes_damage)
+					damage = str(slimes_damage)
 
-                    slimes_tobleed = int((slimes_damage - slimes_drained) / 2)
-                    if ewcfg.mutation_id_bleedingheart in target_mutations:
-                        slimes_tobleed *= 2
+					slimes_tobleed = int((slimes_damage - slimes_drained) / 2)
+					if ewcfg.mutation_id_bleedingheart in target_mutations:
+						slimes_tobleed *= 2
 
-                    slimes_directdamage = slimes_damage - slimes_tobleed
-                    slimes_splatter = slimes_damage - slimes_tobleed - slimes_drained
+					slimes_directdamage = slimes_damage - slimes_tobleed
+					slimes_splatter = slimes_damage - slimes_tobleed - slimes_drained
 
-                    market_data.splattered_slimes += slimes_damage
-                    market_data.persist()
-                    district_data.change_slimes(n=slimes_splatter, source=ewcfg.source_killing)
-                    target_data.bleed_storage += slimes_tobleed
-                    target_data.change_slimes(n=- slimes_directdamage, source=ewcfg.source_damage)
-                    sewer_data.change_slimes(n=slimes_drained)
+					market_data.splattered_slimes += slimes_damage
+					market_data.persist()
+					district_data.change_slimes(n=slimes_splatter, source=ewcfg.source_killing)
+					target_data.bleed_storage += slimes_tobleed
+					target_data.change_slimes(n=- slimes_directdamage, source=ewcfg.source_damage)
+					sewer_data.change_slimes(n=slimes_drained)
 
-                    if was_killed:
+					if was_killed:
 
-                        # Dedorn player cosmetics
-                        ewitem.item_dedorn_cosmetics(id_server=target_data.id_server, id_user=target_data.id_user)
-                        # Drop all items into district
-                        ewitem.item_dropall(id_server=target_data.id_server, id_user=target_data.id_user)
+						# Dedorn player cosmetics
+						ewitem.item_dedorn_cosmetics(id_server=target_data.id_server, id_user=target_data.id_user)
+						# Drop all items into district
+						ewitem.item_dropall(id_server=target_data.id_server, id_user=target_data.id_user)
 
-                        # Give a bonus to the player's weapon skill for killing a stronger player.
-                        # if target_data.slimelevel >= user_data.slimelevel and weapon is not None:
-                        # enemy_data.add_weaponskill(n = 1, weapon_type = weapon.id_weapon)
+						# Give a bonus to the player's weapon skill for killing a stronger player.
+						# if target_data.slimelevel >= user_data.slimelevel and weapon is not None:
+						# enemy_data.add_weaponskill(n = 1, weapon_type = weapon.id_weapon)
 
-                        explode_damage = ewutils.slime_bylevel(target_data.slimelevel) / 5
-                        # explode, damaging everyone in the district
+						explode_damage = ewutils.slime_bylevel(target_data.slimelevel) / 5
+						# explode, damaging everyone in the district
 
-                        # release bleed storage
-                        slimes_todistrict = target_data.slimes
+						# release bleed storage
+						slimes_todistrict = target_data.slimes
 
-                        district_data.change_slimes(n=slimes_todistrict, source=ewcfg.source_killing)
+						district_data.change_slimes(n=slimes_todistrict, source=ewcfg.source_killing)
 
-                        # Player was killed. Remove its id from enemies with defender ai.
-                        enemy_data.id_target = ""
-                        target_data.id_killer = enemy_data.id_enemy
-                        target_data.die(cause=ewcfg.cause_enemy_killing)
-                        #target_data.change_slimes(n=-slimes_dropped / 10, source=ewcfg.source_ghostification)
+						# Player was killed. Remove its id from enemies with defender ai.
+						enemy_data.id_target = ""
+						target_data.id_killer = enemy_data.id_enemy
+						target_data.die(cause=ewcfg.cause_enemy_killing)
+						#target_data.change_slimes(n=-slimes_dropped / 10, source=ewcfg.source_ghostification)
 
-                        kill_descriptor = "beaten to death"
-                        if used_attacktype != ewcfg.enemy_attacktype_unarmed:
-                            response = used_attacktype.str_damage.format(
-                                name_enemy=enemy_data.display_name,
-                                name_target=target_player.display_name,
-                                hitzone=randombodypart,
-                                strikes=strikes
-                            )
-                            kill_descriptor = used_attacktype.str_killdescriptor
-                            if crit:
-                                response += " {}".format(used_attacktype.str_crit.format(
-                                    name_enemy=enemy_data.display_name,
-                                    name_target=target_player.display_name
-                                ))
+						kill_descriptor = "beaten to death"
+						if used_attacktype != ewcfg.enemy_attacktype_unarmed:
+							response = used_attacktype.str_damage.format(
+								name_enemy=enemy_data.display_name,
+								name_target=target_player.display_name,
+								hitzone=randombodypart,
+								strikes=strikes
+							)
+							kill_descriptor = used_attacktype.str_killdescriptor
+							if crit:
+								response += " {}".format(used_attacktype.str_crit.format(
+									name_enemy=enemy_data.display_name,
+									name_target=target_player.display_name
+								))
 
-                            response += "\n\n{}".format(used_attacktype.str_kill.format(
-                                name_enemy=enemy_data.display_name,
-                                name_target=target_player.display_name,
-                                emote_skull=ewcfg.emote_slimeskull
-                            ))
-                            target_data.trauma = used_attacktype.id_type
+							response += "\n\n{}".format(used_attacktype.str_kill.format(
+								name_enemy=enemy_data.display_name,
+								name_target=target_player.display_name,
+								emote_skull=ewcfg.emote_slimeskull
+							))
+							target_data.trauma = used_attacktype.id_type
 
-                        else:
-                            response = "{name_target} is hit!!\n\n{name_target} has died.".format(
-                                name_target=target_player.display_name)
+						else:
+							response = "{name_target} is hit!!\n\n{name_target} has died.".format(
+								name_target=target_player.display_name)
 
-                            target_data.trauma = ""
+							target_data.trauma = ""
 
-                        if target_slimeoid.life_state == ewcfg.slimeoid_state_active:
-                            brain = ewcfg.brain_map.get(target_slimeoid.ai)
-                            response += "\n\n" + brain.str_death.format(slimeoid_name=target_slimeoid.name)
+						if target_slimeoid.life_state == ewcfg.slimeoid_state_active:
+							brain = ewcfg.brain_map.get(target_slimeoid.ai)
+							response += "\n\n" + brain.str_death.format(slimeoid_name=target_slimeoid.name)
 
-                        deathreport = "You were {} by {}. {}".format(kill_descriptor, enemy_data.display_name,
-                                                                     ewcfg.emote_slimeskull)
-                        deathreport = "{} ".format(ewcfg.emote_slimeskull) + ewutils.formatMessage(target_player, deathreport)
+						deathreport = "You were {} by {}. {}".format(kill_descriptor, enemy_data.display_name,
+																	 ewcfg.emote_slimeskull)
+						deathreport = "{} ".format(ewcfg.emote_slimeskull) + ewutils.formatMessage(target_player, deathreport)
 
-                        target_data.persist()
-                        enemy_data.persist()
-                        resp_cont.add_channel_response(ewcfg.channel_sewers, deathreport)
-                        resp_cont.add_channel_response(ch_name, response)
-                        if ewcfg.mutation_id_spontaneouscombustion in target_mutations:
-                            import ewwep
-                            explode_resp = "\n{} spontaneously combusts, horribly dying in a fiery explosion of slime and shrapnel!! Oh, the humanity!".format(
-                                target_player.display_name)
-                            resp_cont.add_channel_response(ch_name, explode_resp)
-                            explosion = await ewutils.explode(damage=explode_damage, district_data=district_data)
-                            resp_cont.add_response_container(explosion)
+						target_data.persist()
+						enemy_data.persist()
+						resp_cont.add_channel_response(ewcfg.channel_sewers, deathreport)
+						resp_cont.add_channel_response(ch_name, response)
+						if ewcfg.mutation_id_spontaneouscombustion in target_mutations:
+							import ewwep
+							explode_resp = "\n{} spontaneously combusts, horribly dying in a fiery explosion of slime and shrapnel!! Oh, the humanity!".format(
+								target_player.display_name)
+							resp_cont.add_channel_response(ch_name, explode_resp)
+							explosion = await ewutils.explode(damage=explode_damage, district_data=district_data)
+							resp_cont.add_response_container(explosion)
 
-                        # don't recreate enemy data if enemy was killed in explosion
-                        if check_death(enemy_data) == False:
-                            enemy_data = EwEnemy(id_enemy=self.id_enemy)
+						# don't recreate enemy data if enemy was killed in explosion
+						if check_death(enemy_data) == False:
+							enemy_data = EwEnemy(id_enemy=self.id_enemy)
 
-                        target_data = EwUser(id_user = target_data.id_user, id_server = target_data.id_server)
-                    else:
-                        # A non-lethal blow!
+						target_data = EwUser(id_user = target_data.id_user, id_server = target_data.id_server)
+					else:
+						# A non-lethal blow!
 
-                        if used_attacktype != ewcfg.enemy_attacktype_unarmed:
-                            if miss:
-                                response = "{}".format(used_attacktype.str_miss.format(
-                                    name_enemy=enemy_data.display_name,
-                                    name_target=target_player.display_name
-                                ))
-                            elif backfire:
-                                response = "{}".format(used_attacktype.str_backfire.format(
-                                    name_enemy = enemy_data.display_name,
-                                    name_target = target_player.display_name
-                                ))
-                            else:
-                                response = used_attacktype.str_damage.format(
-                                    name_enemy=enemy_data.display_name,
-                                    name_target=target_player.display_name,
-                                    hitzone=randombodypart,
-                                    strikes=strikes
-                                )
-                                if crit:
-                                    response += " {}".format(used_attacktype.str_crit.format(
-                                        name_enemy=enemy_data.display_name,
-                                        name_target=target_player.display_name
-                                    ))
-                                response += " {target_name} loses {damage} slime!".format(
-                                    target_name=target_player.display_name,
-                                    damage=damage
-                                )
-                        else:
-                            if miss:
-                                response = "{target_name} dodges the {enemy_name}'s strike.".format(
-                                    target_name=target_player.display_name, enemy_name=enemy_data.display_name)
-                            else:
-                                response = "{target_name} is hit!! {target_name} loses {damage} slime!".format(
-                                    target_name=target_player.display_name,
-                                    damage=damage
-                                )
-                        resp_cont.add_channel_response(ch_name, response)
-                else:
-                    response = '{} is unable to attack {}.'.format(enemy_data.display_name, target_player.display_name)
-                    resp_cont.add_channel_response(ch_name, response)
+						if used_attacktype != ewcfg.enemy_attacktype_unarmed:
+							if miss:
+								response = "{}".format(used_attacktype.str_miss.format(
+									name_enemy=enemy_data.display_name,
+									name_target=target_player.display_name
+								))
+							elif backfire:
+								response = "{}".format(used_attacktype.str_backfire.format(
+									name_enemy = enemy_data.display_name,
+									name_target = target_player.display_name
+								))
+							else:
+								response = used_attacktype.str_damage.format(
+									name_enemy=enemy_data.display_name,
+									name_target=target_player.display_name,
+									hitzone=randombodypart,
+									strikes=strikes
+								)
+								if crit:
+									response += " {}".format(used_attacktype.str_crit.format(
+										name_enemy=enemy_data.display_name,
+										name_target=target_player.display_name
+									))
+								response += " {target_name} loses {damage} slime!".format(
+									target_name=target_player.display_name,
+									damage=damage
+								)
+						else:
+							if miss:
+								response = "{target_name} dodges the {enemy_name}'s strike.".format(
+									target_name=target_player.display_name, enemy_name=enemy_data.display_name)
+							else:
+								response = "{target_name} is hit!! {target_name} loses {damage} slime!".format(
+									target_name=target_player.display_name,
+									damage=damage
+								)
+						resp_cont.add_channel_response(ch_name, response)
+				else:
+					response = '{} is unable to attack {}.'.format(enemy_data.display_name, target_player.display_name)
+					resp_cont.add_channel_response(ch_name, response)
 
-                # Persist user and enemy data.
-                if enemy_data.life_state == ewcfg.enemy_lifestate_alive or enemy_data.life_state == ewcfg.enemy_lifestate_unactivated:
-                    enemy_data.persist()
-                target_data.persist()
+				# Persist user and enemy data.
+				if enemy_data.life_state == ewcfg.enemy_lifestate_alive or enemy_data.life_state == ewcfg.enemy_lifestate_unactivated:
+					enemy_data.persist()
+				target_data.persist()
 
-                district_data.persist()
+				district_data.persist()
 
-                # Assign the corpse role to the newly dead player.
-                if was_killed:
-                    member = server.get_member(target_data.id_user)
-                    await ewrolemgr.updateRoles(client=client, member=member)
-                    # announce death in kill feed channel
-                    # killfeed_channel = ewutils.get_channel(enemy_data.id_server, ewcfg.channel_killfeed)
-                    # killfeed_resp = resp_cont.channel_responses[ch_name]
-                    # for r in killfeed_resp:
-                    #     resp_cont.add_channel_response(ewcfg.channel_killfeed, r)
-                    # resp_cont.format_channel_response(ewcfg.channel_killfeed, enemy_data)
-                    # resp_cont.add_channel_response(ewcfg.channel_killfeed, "`-------------------------`")
-                # await ewutils.send_message(client, killfeed_channel, ewutils.formatMessage(enemy_data.display_name, killfeed_resp))
+				# Assign the corpse role to the newly dead player.
+				if was_killed:
+					member = server.get_member(target_data.id_user)
+					await ewrolemgr.updateRoles(client=client, member=member)
+					# announce death in kill feed channel
+					# killfeed_channel = ewutils.get_channel(enemy_data.id_server, ewcfg.channel_killfeed)
+					# killfeed_resp = resp_cont.channel_responses[ch_name]
+					# for r in killfeed_resp:
+					#	 resp_cont.add_channel_response(ewcfg.channel_killfeed, r)
+					# resp_cont.format_channel_response(ewcfg.channel_killfeed, enemy_data)
+					# resp_cont.add_channel_response(ewcfg.channel_killfeed, "`-------------------------`")
+				# await ewutils.send_message(client, killfeed_channel, ewutils.formatMessage(enemy_data.display_name, killfeed_resp))
 
-        # Send the response to the player.
-        resp_cont.format_channel_response(ch_name, enemy_data)
-        if should_post_resp_cont:
-            await resp_cont.post()
+		# Send the response to the player.
+		resp_cont.format_channel_response(ch_name, enemy_data)
+		if should_post_resp_cont:
+			await resp_cont.post()
 
-    def move(self):
-        resp_cont = ewutils.EwResponseContainer(id_server=self.id_server)
+	def move(self):
+		resp_cont = ewutils.EwResponseContainer(id_server=self.id_server)
 
-        old_district_response = ""
-        new_district_response = ""
-        gang_base_response = ""
+		old_district_response = ""
+		new_district_response = ""
+		gang_base_response = ""
 
-        try:
-            # Raid bosses can only move into the city (capturable districts), never back into the outskirts.
-            destinations = ewcfg.poi_neighbors.get(self.poi).intersection(set(ewcfg.capturable_districts))
-            if len(destinations) > 0:
-                old_poi = self.poi
-                new_poi = random.choice(list(destinations))
-                self.poi = new_poi
-                self.time_lastenter = int(time.time())
-                self.id_target = ""
+		try:
+			# Raid bosses can only move into the city (capturable districts), never back into the outskirts.
+			destinations = ewcfg.poi_neighbors.get(self.poi).intersection(set(ewcfg.capturable_districts))
+			if len(destinations) > 0:
+				old_poi = self.poi
+				new_poi = random.choice(list(destinations))
+				self.poi = new_poi
+				self.time_lastenter = int(time.time())
+				self.id_target = ""
 
-                # print("DEBUG - {} MOVED FROM {} TO {}".format(self.display_name, old_poi, new_poi))
+				# print("DEBUG - {} MOVED FROM {} TO {}".format(self.display_name, old_poi, new_poi))
 
-                #new_district = EwDistrict(district=new_poi, id_server=self.id_server)
-                #if len(new_district.get_enemies_in_district() > 0:
+				#new_district = EwDistrict(district=new_poi, id_server=self.id_server)
+				#if len(new_district.get_enemies_in_district() > 0:
 
-                # When a raid boss enters a new district, give it a new identifier
-                self.identifier = set_identifier(new_poi, self.id_server)
+				# When a raid boss enters a new district, give it a new identifier
+				self.identifier = set_identifier(new_poi, self.id_server)
 
-                new_poi_def = ewcfg.id_to_poi.get(new_poi)
-                new_ch_name = new_poi_def.channel
-                new_district_response = "*A low roar booms throughout the district, as slime on the ground begins to slosh all around.*\n {} **{} has arrived!** {}".format(
-                    ewcfg.emote_megaslime,
-                    self.display_name,
-                    ewcfg.emote_megaslime
-                )
-                resp_cont.add_channel_response(new_ch_name, new_district_response)
+				new_poi_def = ewcfg.id_to_poi.get(new_poi)
+				new_ch_name = new_poi_def.channel
+				new_district_response = "*A low roar booms throughout the district, as slime on the ground begins to slosh all around.*\n {} **{} has arrived!** {}".format(
+					ewcfg.emote_megaslime,
+					self.display_name,
+					ewcfg.emote_megaslime
+				)
+				resp_cont.add_channel_response(new_ch_name, new_district_response)
 
-                old_district_response = "{} has moved to {}!".format(self.display_name, new_poi_def.str_name)
-                old_poi_def = ewcfg.id_to_poi.get(old_poi)
-                old_ch_name = old_poi_def.channel
-                resp_cont.add_channel_response(old_ch_name, old_district_response)
+				old_district_response = "{} has moved to {}!".format(self.display_name, new_poi_def.str_name)
+				old_poi_def = ewcfg.id_to_poi.get(old_poi)
+				old_ch_name = old_poi_def.channel
+				resp_cont.add_channel_response(old_ch_name, old_district_response)
 
-                gang_base_response = "There are reports of a powerful enemy roaming around {}.".format(new_poi_def.str_name)
-                resp_cont.add_channel_response(ewcfg.channel_rowdyroughhouse, gang_base_response)
-                resp_cont.add_channel_response(ewcfg.channel_copkilltown, gang_base_response)
-        finally:
-            self.persist()
-            return resp_cont
+				gang_base_response = "There are reports of a powerful enemy roaming around {}.".format(new_poi_def.str_name)
+				resp_cont.add_channel_response(ewcfg.channel_rowdyroughhouse, gang_base_response)
+				resp_cont.add_channel_response(ewcfg.channel_copkilltown, gang_base_response)
+		finally:
+			self.persist()
+			return resp_cont
 
-    def change_slimes(self, n=0, source=None):
-        change = int(n)
-        self.slimes += change
+	def change_slimes(self, n=0, source=None):
+		change = int(n)
+		self.slimes += change
 
-        if n < 0:
-            change *= -1  # convert to positive number
-            if source == ewcfg.source_damage or source == ewcfg.source_bleeding or source == ewcfg.source_self_damage:
-                self.totaldamage += change
+		if n < 0:
+			change *= -1  # convert to positive number
+			if source == ewcfg.source_damage or source == ewcfg.source_bleeding or source == ewcfg.source_self_damage:
+				self.totaldamage += change
 
-        self.persist()
+		self.persist()
 
 # Reskinned version of effect container from ewwep.
 class EwEnemyEffectContainer:
-    miss = False
-    backfire = False
-    crit = False
-    strikes = 0
-    slimes_damage = 0
-    enemy_data = None
-    target_data = None
+	miss = False
+	backfire = False
+	crit = False
+	strikes = 0
+	slimes_damage = 0
+	enemy_data = None
+	target_data = None
 
-    # Debug method to dump out the members of this object.
-    def dump(self):
-        print(
-            "effect:\nmiss: {miss}\ncrit: {crit}\nbackfire: {backfire}\nstrikes: {strikes}\nslimes_damage: {slimes_damage}\nslimes_spent: {slimes_spent}".format(
-                miss=self.miss,
-                backfire=self.backfire,
-                crit=self.crit,
-                strikes=self.strikes,
-                slimes_damage=self.slimes_damage,
-                slimes_spent=self.slimes_spent
-            ))
+	# Debug method to dump out the members of this object.
+	def dump(self):
+		print(
+			"effect:\nmiss: {miss}\ncrit: {crit}\nbackfire: {backfire}\nstrikes: {strikes}\nslimes_damage: {slimes_damage}\nslimes_spent: {slimes_spent}".format(
+				miss=self.miss,
+				backfire=self.backfire,
+				crit=self.crit,
+				strikes=self.strikes,
+				slimes_damage=self.slimes_damage,
+				slimes_spent=self.slimes_spent
+			))
 
-    def __init__(
-            self,
-            miss=False,
-            backfire=False,
-            crit=False,
-            strikes=0,
-            slimes_damage=0,
-            slimes_spent=0,
-            enemy_data=None,
-            target_data=None
-    ):
-        self.miss = miss
-        self.backfire = backfire
-        self.crit = crit
-        self.strikes = strikes
-        self.slimes_damage = slimes_damage
-        self.slimes_spent = slimes_spent
-        self.enemy_data = enemy_data
-        self.target_data = target_data
+	def __init__(
+			self,
+			miss=False,
+			backfire=False,
+			crit=False,
+			strikes=0,
+			slimes_damage=0,
+			slimes_spent=0,
+			enemy_data=None,
+			target_data=None
+	):
+		self.miss = miss
+		self.backfire = backfire
+		self.crit = crit
+		self.strikes = strikes
+		self.slimes_damage = slimes_damage
+		self.slimes_spent = slimes_spent
+		self.enemy_data = enemy_data
+		self.target_data = target_data
 
 # Debug command. Could be used for events, perhaps?
 async def summon_enemy(cmd):
-    author = cmd.message.author
+	author = cmd.message.author
 
-    if not author.server_permissions.administrator:
-        return
+	if not author.server_permissions.administrator:
+		return
 
-    time_now = int(time.time())
-    response = ""
-    user_data = EwUser(member=cmd.message.author)
+	time_now = int(time.time())
+	response = ""
+	user_data = EwUser(member=cmd.message.author)
 
-    enemytype = None
-    enemy_location = None
-    poi = None
-    enemy_slimes = None
-    enemy_displayname = None
-    enemy_level = None
+	enemytype = None
+	enemy_location = None
+	poi = None
+	enemy_slimes = None
+	enemy_displayname = None
+	enemy_level = None
 
-    if len(cmd.tokens) >= 3:
-        enemytype = cmd.tokens[1]
-        enemy_location = cmd.tokens[2]
-        if len(cmd.tokens) >= 6:
-            enemy_slimes = cmd.tokens[3]
-            enemy_level = cmd.tokens[4]
-            enemy_displayname = " ".join(cmd.tokens[5:])
-    
-        poi = ewcfg.id_to_poi.get(enemy_location)
+	if len(cmd.tokens) >= 3:
+		enemytype = cmd.tokens[1]
+		enemy_location = cmd.tokens[2]
+		if len(cmd.tokens) >= 6:
+			enemy_slimes = cmd.tokens[3]
+			enemy_level = cmd.tokens[4]
+			enemy_displayname = " ".join(cmd.tokens[5:])
+	
+		poi = ewcfg.id_to_poi.get(enemy_location)
 
-    if enemytype != None and poi != None:
+	if enemytype != None and poi != None:
 
-        enemy = get_enemy_data(enemytype)
+		enemy = get_enemy_data(enemytype)
 
-        # Assign enemy attributes that weren't assigned in get_enemy_data
-        enemy.id_server = user_data.id_server
-        enemy.poi = poi.id_poi
-        enemy.level = level_byslime(enemy.slimes)
-        enemy.lifetime = time_now
-        enemy.identifier = set_identifier(poi.id_poi, user_data.id_server)
-        
-        # Re-assign rare_status to 0 so custom names don't confuse the dict in ewcfg
-        enemy.rare_status = 0
-        
-        if enemy_slimes != None and enemy_displayname != None and enemy_level != None:
-            enemy.initialslimes = enemy_slimes
-            enemy.slimes = enemy_slimes
-            enemy.display_name = enemy_displayname
-            enemy.level = enemy_level
+		# Assign enemy attributes that weren't assigned in get_enemy_data
+		enemy.id_server = user_data.id_server
+		enemy.poi = poi.id_poi
+		enemy.level = level_byslime(enemy.slimes)
+		enemy.lifetime = time_now
+		enemy.identifier = set_identifier(poi.id_poi, user_data.id_server)
+		
+		# Re-assign rare_status to 0 so custom names don't confuse the dict in ewcfg
+		enemy.rare_status = 0
+		
+		if enemy_slimes != None and enemy_displayname != None and enemy_level != None:
+			enemy.initialslimes = enemy_slimes
+			enemy.slimes = enemy_slimes
+			enemy.display_name = enemy_displayname
+			enemy.level = enemy_level
 
-        enemy.persist()
+		enemy.persist()
 
-        response = "**DEBUG**: You have summoned **{}**, a level {} enemy of type **{}**. It has {} slime. It spawned in {}.".format(
-            enemy.display_name,
-            enemy.level,
-            enemy.enemytype,
-            enemy.slimes,
-            enemy.poi
-        )
-        
-    else:
-        response = "**DEBUG**: PLEASE RE-SUMMON WITH APPLICABLE TYPING / LOCATION. ADDITIONAL OPTIONS ARE SLIME / LEVEL / DISPLAYNAME"
+		response = "**DEBUG**: You have summoned **{}**, a level {} enemy of type **{}**. It has {} slime. It spawned in {}.".format(
+			enemy.display_name,
+			enemy.level,
+			enemy.enemytype,
+			enemy.slimes,
+			enemy.poi
+		)
+		
+	else:
+		response = "**DEBUG**: PLEASE RE-SUMMON WITH APPLICABLE TYPING / LOCATION. ADDITIONAL OPTIONS ARE SLIME / LEVEL / DISPLAYNAME"
 
-    await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+	await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
 
 # Gathers all enemies from the database (that are either raid bosses or have users in the same district as them) and has them perform an action
 async def enemy_perform_action(id_server):
-    
-    despawn_timenow = int(time.time()) - ewcfg.time_despawn
+	
+	despawn_timenow = int(time.time()) - ewcfg.time_despawn
+	
+	print("TEST")
 
-#	enemydata = ewutils.execute_sql_query(
-#       "SELECT {id_enemy} FROM users, enemies WHERE (users.poi = enemies.poi AND users.life_state != %s AND enemies.id_server = '{id_server}' AND users.id_server = '{id_server}') OR (enemies.enemytype IN %s AND enemies.id_server = '{id_server}') OR (enemies.life_state = %s OR enemies.lifetime < %s)".format(
-#           id_enemy=ewcfg.col_id_enemy,
-#           id_server=id_server
-#       ), (
-#           ewcfg.life_state_corpse,
-#           ewcfg.raid_bosses,
-#           ewcfg.enemy_lifestate_dead,
-#           despawn_timenow
-#       ))
-    enemydata = ewutils.execute_sql_query("SELECT {id_enemy} FROM enemies WHERE id_server = %s".format(
-        id_enemy = ewcfg.col_id_enemy
-    ),(
-        id_server,
-    ))
+	enemydata = ewutils.execute_sql_query(
+	  "SELECT {id_enemy} FROM users, enemies WHERE ((users.poi = enemies.poi AND (users.life_state != %s OR users.life_state != %s) AND users.id_server = '{id_server}') OR (enemies.enemytype IN %s) OR (enemies.life_state = %s OR enemies.lifetime < %s)) AND enemies.id_server = '{id_server}'".format(
+		  id_enemy=ewcfg.col_id_enemy,
+		  id_server=id_server
+	  ), (
+		  ewcfg.life_state_corpse,
+		  ewcfg.life_state_kingpin,
+		  ewcfg.raid_bosses,
+		  ewcfg.enemy_lifestate_dead,
+		  despawn_timenow
+	  ))
+	# enemydata = ewutils.execute_sql_query("SELECT {id_enemy} FROM enemies WHERE id_server = %s".format(
+	#     id_enemy = ewcfg.col_id_enemys
+	# ),(
+	#     id_server,
+	# ))
 
-    # Remove duplicates from SQL query
-#enemydata = list(dict.fromkeys(enemydata))
+	# Remove duplicates from SQL query
+	enemydata = list(dict.fromkeys(enemydata))
+	print("ENEMYDATA: {}".format(enemydata))
 
-    for row in enemydata:
-        enemy = EwEnemy(id_enemy=row[0], id_server=id_server)
+	for row in enemydata:
+		enemy = EwEnemy(id_enemy=row[0], id_server=id_server)
+		#print(enemy.enemytype)
 
-        # If an enemy is marked for death or has been alive too long, delete it
-        if enemy.life_state == ewcfg.enemy_lifestate_dead or (enemy.lifetime < despawn_timenow):
-            delete_enemy(enemy)
-        else:
-            # If an enemy is an activated raid boss, it has a 1/20 chance to move between districts.
-            if enemy.enemytype in ewcfg.raid_bosses and enemy.life_state == ewcfg.enemy_lifestate_alive and check_raidboss_movecooldown(enemy):
-                if random.randrange(20) == 0:
-                    resp_cont = enemy.move()
-                    if resp_cont != None:
-                        await resp_cont.post()
+		# If an enemy is marked for death or has been alive too long, delete it
+		if enemy.life_state == ewcfg.enemy_lifestate_dead or (enemy.lifetime < despawn_timenow):
+			delete_enemy(enemy)
+		else:
+			# If an enemy is an activated raid boss, it has a 1/20 chance to move between districts.
+			if enemy.enemytype in ewcfg.raid_bosses and enemy.life_state == ewcfg.enemy_lifestate_alive and check_raidboss_movecooldown(enemy):
+				if random.randrange(20) == 0:
+					resp_cont = enemy.move()
+					if resp_cont != None:
+						await resp_cont.post()
 
-            # If an enemy is alive, make it peform the kill function.
-            resp_cont = await enemy.kill()
-            if resp_cont != None:
-                await resp_cont.post()
+			# If an enemy is alive, make it peform the kill function.
+			resp_cont = await enemy.kill()
+			if resp_cont != None:
+				await resp_cont.post()
 
 # Spawns an enemy in a randomized outskirt district. If a district is full, it will try again, up to 5 times.
 async def spawn_enemy(id_server):
-    time_now = int(time.time())
-    response = ""
-    ch_name = ""
-    chosen_poi = ""
+	time_now = int(time.time())
+	response = ""
+	ch_name = ""
+	chosen_poi = ""
+	threat_level = ""
+	boss_choices = []
 
-    enemies_count = ewcfg.max_enemies
-    try_count = 0
+	enemies_count = ewcfg.max_enemies
+	try_count = 0
 
-    rarity_choice = random.randrange(10000)
+	rarity_choice = random.randrange(10000)
 
-    if rarity_choice <= 4500:
-        # common enemies
-        enemytype = random.choice(ewcfg.common_enemies)
-    elif rarity_choice <= 7200:
-        # uncommon enemies
-        enemytype = random.choice(ewcfg.uncommon_enemies)
-    elif rarity_choice <= 9000:
-        # rare enemies
-        enemytype = random.choice(ewcfg.rare_enemies)
-    else:
-        # raid bosses
-        enemytype = random.choice(ewcfg.raid_bosses)
+	if rarity_choice <= 4500:
+		# common enemies
+		enemytype = random.choice(ewcfg.common_enemies)
+	elif rarity_choice <= 7200:
+		# uncommon enemies
+		enemytype = random.choice(ewcfg.uncommon_enemies)
+	elif rarity_choice <= 9000:
+		# rare enemies
+		enemytype = random.choice(ewcfg.rare_enemies)
+	else:
+		# raid bosses
+		threat_level_choice = random.randrange(1000)
+		
+		if threat_level_choice <= 450:
+			threat_level = "Micro"
+		elif threat_level_choice <= 720:
+			threat_level = "Monstrous"
+		elif threat_level_choice <= 900:
+			threat_level = "Mega"
+		else:
+			threat_level = "Mega"
+			#threat_level = "Nega"
+		
+		boss_choices = ewcfg.raid_boss_tiers[threat_level]
+		enemytype = random.choice(boss_choices)
+		
 
-    # debug manual reassignment
-    # enemytype = 'juvie'
+	# debug manual reassignment
+	# enemytype = 'juvie'
 
-    while enemies_count >= ewcfg.max_enemies and try_count < 5:
+	while enemies_count >= ewcfg.max_enemies and try_count < 5:
 
-        potential_chosen_poi = random.choice(ewcfg.outskirts_districts)
-        # potential_chosen_poi = 'cratersvilleoutskirts'
-        potential_chosen_district = EwDistrict(district=potential_chosen_poi, id_server=id_server)
-        enemies_list = potential_chosen_district.get_enemies_in_district()
-        enemies_count = len(enemies_list)
+		potential_chosen_poi = random.choice(ewcfg.outskirts_districts)
+		# potential_chosen_poi = 'cratersvilleoutskirts'
+		potential_chosen_district = EwDistrict(district=potential_chosen_poi, id_server=id_server)
+		enemies_list = potential_chosen_district.get_enemies_in_district()
+		enemies_count = len(enemies_list)
 
-        if enemies_count < ewcfg.max_enemies:
-            chosen_poi = potential_chosen_poi
-            try_count = 5
-        else:
-            # Enemy couldn't spawn in that district, try again
-            try_count += 1
+		if enemies_count < ewcfg.max_enemies:
+			chosen_poi = potential_chosen_poi
+			try_count = 5
+		else:
+			# Enemy couldn't spawn in that district, try again
+			try_count += 1
 
-    if enemytype != None and chosen_poi != "":
-        enemy = get_enemy_data(enemytype)
+	if enemytype != None and chosen_poi != "":
+		enemy = get_enemy_data(enemytype)
 
-        # Assign enemy attributes that weren't assigned in get_enemy_data
-        enemy.id_server = id_server
-        enemy.level = level_byslime(enemy.slimes)
-        enemy.lifetime = time_now
-        enemy.initialslimes = enemy.slimes
-        enemy.poi = chosen_poi
-        enemy.identifier = set_identifier(chosen_poi, id_server)
+		# Assign enemy attributes that weren't assigned in get_enemy_data
+		enemy.id_server = id_server
+		enemy.level = level_byslime(enemy.slimes)
+		enemy.lifetime = time_now
+		enemy.initialslimes = enemy.slimes
+		enemy.poi = chosen_poi
+		enemy.identifier = set_identifier(chosen_poi, id_server)
 
-        enemy.persist()
+		enemy.persist()
 
-        if enemytype not in ewcfg.raid_bosses:
-            response = "**An enemy draws near!!** It's a level {} {}, and has {} slime.".format(enemy.level, enemy.display_name, enemy.slimes)
-        ch_name = ewcfg.id_to_poi.get(enemy.poi).channel
+		if enemytype not in ewcfg.raid_bosses:
+			response = "**An enemy draws near!!** It's a level {} {}, and has {} slime.".format(enemy.level, enemy.display_name, enemy.slimes)
+		ch_name = ewcfg.id_to_poi.get(enemy.poi).channel
 
-    return response, ch_name
+	return response, ch_name
 
 # Finds an enemy based on its regular/shorthand name, or its ID.
 def find_enemy(enemy_search=None, user_data=None):
-    enemy_found = None
-    enemy_search_alias = None
-    
+	enemy_found = None
+	enemy_search_alias = None
+	
 
-    if enemy_search != None:
+	if enemy_search != None:
 
-        for enemy_type in ewcfg.enemy_aliases:
-            if enemy_search.lower() in ewcfg.enemy_aliases[enemy_type]:
-                enemy_search_alias = enemy_type
-                continue
+		for enemy_type in ewcfg.enemy_aliases:
+			if enemy_search.lower() in ewcfg.enemy_aliases[enemy_type]:
+				enemy_search_alias = enemy_type
+				continue
 
-        enemy_search_tokens = enemy_search.split(' ')
+		enemy_search_tokens = enemy_search.split(' ')
 
-        if enemy_search_tokens[len(enemy_search_tokens) - 1].upper() in ewcfg.identifier_letters:
-            # user passed in an identifier for a district specific enemy
+		if enemy_search_tokens[len(enemy_search_tokens) - 1].upper() in ewcfg.identifier_letters:
+			# user passed in an identifier for a district specific enemy
 
-            searched_identifier = enemy_search_tokens[len(enemy_search_tokens) - 1]
+			searched_identifier = enemy_search_tokens[len(enemy_search_tokens) - 1].upper()
 
-            enemydata = ewutils.execute_sql_query(
-                "SELECT {id_enemy} FROM enemies WHERE {poi} = %s AND {identifier} = %s AND {life_state} = 1".format(
-                    id_enemy=ewcfg.col_id_enemy,
-                    poi=ewcfg.col_enemy_poi,
-                    identifier=ewcfg.col_enemy_identifier,
-                    life_state=ewcfg.col_enemy_life_state
-                ), (
-                    user_data.poi,
-                    searched_identifier,
-                ))
+			enemydata = ewutils.execute_sql_query(
+				"SELECT {id_enemy} FROM enemies WHERE {poi} = %s AND {identifier} = %s AND {life_state} = 1".format(
+					id_enemy=ewcfg.col_id_enemy,
+					poi=ewcfg.col_enemy_poi,
+					identifier=ewcfg.col_enemy_identifier,
+					life_state=ewcfg.col_enemy_life_state
+				), (
+					user_data.poi,
+					searched_identifier,
+				))
 
-            for row in enemydata:
-                enemy = EwEnemy(id_enemy=row[0], id_server=user_data.id_server)
-                enemy_found = enemy
-                break
-        else:
-            # last token was a string, identify enemy by name
+			for row in enemydata:
+				enemy = EwEnemy(id_enemy=row[0], id_server=user_data.id_server)
+				enemy_found = enemy
+				break
+		else:
+			# last token was a string, identify enemy by name
 
-            enemydata = ewutils.execute_sql_query("SELECT {id_enemy} FROM enemies WHERE {poi} = %s AND {life_state} = 1".format(
-                id_enemy=ewcfg.col_id_enemy,
-                poi=ewcfg.col_enemy_poi,
-                life_state=ewcfg.col_enemy_life_state
-            ), (
-                user_data.poi,
-            ))
+			enemydata = ewutils.execute_sql_query("SELECT {id_enemy} FROM enemies WHERE {poi} = %s AND {life_state} = 1".format(
+				id_enemy=ewcfg.col_id_enemy,
+				poi=ewcfg.col_enemy_poi,
+				life_state=ewcfg.col_enemy_life_state
+			), (
+				user_data.poi,
+			))
 
-            # find the first (i.e. the oldest) item that matches the search
-            for row in enemydata:
-                enemy = EwEnemy(id_enemy=row[0], id_server=user_data.id_server)
-                
-                if (enemy.display_name.lower() == enemy_search) or (enemy.enemytype == enemy_search_alias):
-                    enemy_found = enemy
-                    break
+			# find the first (i.e. the oldest) item that matches the search
+			for row in enemydata:
+				enemy = EwEnemy(id_enemy=row[0], id_server=user_data.id_server)
+				
+				if (enemy.display_name.lower() == enemy_search) or (enemy.enemytype == enemy_search_alias):
+					enemy_found = enemy
+					break
 
-    return enemy_found
+	return enemy_found
 
 # Deletes an enemy the database.
 def delete_enemy(enemy_data):
-    # print("DEBUG - {} - {} DELETED".format(enemy_data.id_enemy, enemy_data.display_name))
-    ewutils.execute_sql_query("DELETE FROM enemies WHERE {id_enemy} = %s".format(
-        id_enemy=ewcfg.col_id_enemy
-    ), (
-        enemy_data.id_enemy,
-    ))
+	# print("DEBUG - {} - {} DELETED".format(enemy_data.id_enemy, enemy_data.display_name))
+	ewutils.execute_sql_query("DELETE FROM enemies WHERE {id_enemy} = %s".format(
+		id_enemy=ewcfg.col_id_enemy
+	), (
+		enemy_data.id_enemy,
+	))
 
 # Drops items into the district when an enemy dies.
 def drop_enemy_loot(enemy_data, district_data):
-    response = ""
+	response = ""
 
-    item_counter = 0
-    loot_multiplier = 1
+	item_counter = 0
+	loot_multiplier = 1
 
-    poudrin_dropped = False
-    poudrin_amount = 0
+	poudrin_dropped = False
+	poudrin_amount = 0
 
-    pleb_dropped = False
-    pleb_amount = 0
+	pleb_dropped = False
+	pleb_amount = 0
 
-    patrician_dropped = False
-    patrician_amount = 0
+	patrician_dropped = False
+	patrician_amount = 0
 
-    crop_dropped = False
-    crop_amount = 0
+	crop_dropped = False
+	crop_amount = 0
 
-    meat_dropped = False
-    meat_amount = 0
+	meat_dropped = False
+	meat_amount = 0
 
-    card_dropped = False
-    card_amount = 0
-    
-    drop_chance = None
-    drop_min = None
-    drop_max = None
-    drop_range = None
-    
-    poudrin_values = None
-    pleb_values = None
-    patrician_values = None
-    crop_values = None
-    meat_values = None
-    card_values = None
-    
-    drop_table = ewcfg.enemy_drop_tables[enemy_data.enemytype]
-    
-    # Go through all the possible drops in the drop table and catch exceptions when necessary
-    for item in drop_table:
-        try:
-            if item["poudrin"]:
-                poudrin_values = item["poudrin"]
-        except:
-            pass
-        try:
-            if item["pleb"]:
-                pleb_values = item["pleb"]
-        except:
-            pass
-        try:
-            if item["patrician"]:
-                patrician_values = item["patrician"]
-        except:
-            pass
-        try:
-            if item["crop"]:
-                crop_values = item["crop"]
-        except:
-            pass
-        try:
-            if item["meat"]:
-                meat_values = item["meat"]
-        except:
-            pass
-        try:
-            if item["card"]:
-                card_values = item["card"]
-        except:
-            pass
-        
-    if poudrin_values != None:
-        drop_chance = poudrin_values[0]
-        drop_min = poudrin_values[1]
-        drop_max = poudrin_values[2]
-        
-        poudrin_dropped = random.randrange(100) <= (drop_chance - 1)
-        
-        if poudrin_dropped:
-            drop_range = list(range(drop_min, drop_max+1))
-            poudrin_amount = random.choice(drop_range)
-            
-    if pleb_values != None:
-        drop_chance = pleb_values[0]
-        drop_min = pleb_values[1]
-        drop_max = pleb_values[2]
-        
-        pleb_dropped = random.randrange(101) < drop_chance
-        
-        if pleb_dropped:
-            drop_range = list(range(drop_min, drop_max + 1))
-            pleb_amount = random.choice(drop_range)
+	card_dropped = False
+	card_amount = 0
+	
+	drop_chance = None
+	drop_min = None
+	drop_max = None
+	drop_range = None
+	
+	poudrin_values = None
+	pleb_values = None
+	patrician_values = None
+	crop_values = None
+	meat_values = None
+	card_values = None
+	
+	drop_table = ewcfg.enemy_drop_tables[enemy_data.enemytype]
+	
+	# Go through all the possible drops in the drop table and catch exceptions when necessary
+	for item in drop_table:
+		try:
+			if item["poudrin"]:
+				poudrin_values = item["poudrin"]
+		except:
+			pass
+		try:
+			if item["pleb"]:
+				pleb_values = item["pleb"]
+		except:
+			pass
+		try:
+			if item["patrician"]:
+				patrician_values = item["patrician"]
+		except:
+			pass
+		try:
+			if item["crop"]:
+				crop_values = item["crop"]
+		except:
+			pass
+		try:
+			if item["meat"]:
+				meat_values = item["meat"]
+		except:
+			pass
+		try:
+			if item["card"]:
+				card_values = item["card"]
+		except:
+			pass
+		
+	if poudrin_values != None:
+		drop_chance = poudrin_values[0]
+		drop_min = poudrin_values[1]
+		drop_max = poudrin_values[2]
+		
+		poudrin_dropped = random.randrange(100) <= (drop_chance - 1)
+		
+		if poudrin_dropped:
+			drop_range = list(range(drop_min, drop_max+1))
+			poudrin_amount = random.choice(drop_range)
+			
+	if pleb_values != None:
+		drop_chance = pleb_values[0]
+		drop_min = pleb_values[1]
+		drop_max = pleb_values[2]
+		
+		pleb_dropped = random.randrange(101) < drop_chance
+		
+		if pleb_dropped:
+			drop_range = list(range(drop_min, drop_max + 1))
+			pleb_amount = random.choice(drop_range)
 
-    if patrician_values != None:
-        drop_chance = patrician_values[0]
-        drop_min = patrician_values[1]
-        drop_max = patrician_values[2]
+	if patrician_values != None:
+		drop_chance = patrician_values[0]
+		drop_min = patrician_values[1]
+		drop_max = patrician_values[2]
 
-        patrician_dropped = random.randrange(101) < drop_chance
+		patrician_dropped = random.randrange(101) < drop_chance
 
-        if patrician_dropped:
-            drop_range = list(range(drop_min, drop_max + 1))
-            patrician_amount = random.choice(drop_range)
+		if patrician_dropped:
+			drop_range = list(range(drop_min, drop_max + 1))
+			patrician_amount = random.choice(drop_range)
 
-    if crop_values != None:
-        drop_chance = crop_values[0]
-        drop_min = crop_values[1]
-        drop_max = crop_values[2]
+	if crop_values != None:
+		drop_chance = crop_values[0]
+		drop_min = crop_values[1]
+		drop_max = crop_values[2]
 
-        crop_dropped = random.randrange(101) < drop_chance
+		crop_dropped = random.randrange(101) < drop_chance
 
-        if crop_dropped:
-            drop_range = list(range(drop_min, drop_max + 1))
-            crop_amount = random.choice(drop_range)
+		if crop_dropped:
+			drop_range = list(range(drop_min, drop_max + 1))
+			crop_amount = random.choice(drop_range)
 
-    if meat_values != None:
-        drop_chance = meat_values[0]
-        drop_min = meat_values[1]
-        drop_max = meat_values[2]
+	if meat_values != None:
+		drop_chance = meat_values[0]
+		drop_min = meat_values[1]
+		drop_max = meat_values[2]
 
-        meat_dropped = random.randrange(101) < drop_chance
+		meat_dropped = random.randrange(101) < drop_chance
 
-        if meat_dropped:
-            drop_range = list(range(drop_min, drop_max + 1))
-            meat_amount = random.choice(drop_range)
+		if meat_dropped:
+			drop_range = list(range(drop_min, drop_max + 1))
+			meat_amount = random.choice(drop_range)
 
-    if card_values != None:
-        drop_chance = card_values[0]
-        drop_min = card_values[1]
-        drop_max = card_values[2]
+	if card_values != None:
+		drop_chance = card_values[0]
+		drop_min = card_values[1]
+		drop_max = card_values[2]
 
-        card_dropped = random.randrange(101) < drop_chance
+		card_dropped = random.randrange(101) < drop_chance
 
-        if card_dropped:
-            drop_range = list(range(drop_min, drop_max + 1))
-            card_amount = random.choice(drop_range)
+		if card_dropped:
+			drop_range = list(range(drop_min, drop_max + 1))
+			card_amount = random.choice(drop_range)
 
-    if pleb_dropped or patrician_dropped:
-        cosmetics_list = []
+	if pleb_dropped or patrician_dropped:
+		cosmetics_list = []
 
-        for result in ewcfg.cosmetic_items_list:
-            if result.ingredients == "":
-                cosmetics_list.append(result)
-            else:
-                pass
-            
-    # Multiply the amount of loot if an enemy is its rare variant
-    # Loot is also multiplied for the UFO raid boss, since it's a special case with the increased variety of slime it can have.
-    if enemy_data.rare_status == 1:
-        loot_multiplier *= 1.5
-        
-    if enemy_data.enemytype == ewcfg.enemy_type_unnervingfightingoperator:
-        if enemy_data.rare_status == 0:
-            if enemy_data.slimes >= 2000000:
-                loot_multiplier *= 6
-            elif enemy_data.slimes >= 1500000:
-                loot_multiplier *= 5
-            else:
-                loot_multiplier *= 4
-        elif enemy_data.rare_status == 1:
-            if enemy_data.slimes >= 4000000:
-                loot_multiplier *= 6
-            elif enemy_data.slimes >= 3000000:
-                loot_multiplier *= 5
-            else:
-                loot_multiplier *= 4
-        
-    poudrin_amount = math.ceil(poudrin_amount * loot_multiplier)
-    pleb_amount = math.ceil(pleb_amount * loot_multiplier)
-    patrician_amount = math.ceil(patrician_amount * loot_multiplier)
-    crop_amount = math.ceil(crop_amount * loot_multiplier)
-    meat_amount = math.ceil(meat_amount * loot_multiplier)
-    card_amount = math.ceil(card_amount * loot_multiplier)
+		for result in ewcfg.cosmetic_items_list:
+			if result.ingredients == "":
+				cosmetics_list.append(result)
+			else:
+				pass
+			
+	# Multiply the amount of loot if an enemy is its rare variant
+	# Loot is also multiplied for the UFO raid boss, since it's a special case with the increased variety of slime it can have.
+	if enemy_data.rare_status == 1:
+		loot_multiplier *= 1.5
+		
+	if enemy_data.enemytype == ewcfg.enemy_type_unnervingfightingoperator:
+		loot_multiplier *= math.ceil(enemy_data.slimes / 1000000)
+		
+	poudrin_amount = math.ceil(poudrin_amount * loot_multiplier)
+	pleb_amount = math.ceil(pleb_amount * loot_multiplier)
+	patrician_amount = math.ceil(patrician_amount * loot_multiplier)
+	crop_amount = math.ceil(crop_amount * loot_multiplier)
+	meat_amount = math.ceil(meat_amount * loot_multiplier)
+	card_amount = math.ceil(card_amount * loot_multiplier)
 
-    # Drops items one-by-one
-    if poudrin_dropped:
-        item_counter = 0
+	# Drops items one-by-one
+	if poudrin_dropped:
+		item_counter = 0
 
-        while item_counter < poudrin_amount:
-            for item in ewcfg.item_list:
-                if item.context == "poudrin":
-                    ewitem.item_create(
-                        item_type=ewcfg.it_item,
-                        id_user=district_data.name,
-                        id_server=district_data.id_server,
-                        item_props={
-                            'id_item': item.id_item,
-                            'context': item.context,
-                            'item_name': item.str_name,
-                            'item_desc': item.str_desc,
-                        }
-                    ),
-                    item = EwItem(id_item=item.id_item)
-                    item.persist()
-            response += "They dropped a slime poudrin!\n"
+		while item_counter < poudrin_amount:
+			for item in ewcfg.item_list:
+				if item.context == "poudrin":
+					ewitem.item_create(
+						item_type=ewcfg.it_item,
+						id_user=district_data.name,
+						id_server=district_data.id_server,
+						item_props={
+							'id_item': item.id_item,
+							'context': item.context,
+							'item_name': item.str_name,
+							'item_desc': item.str_desc,
+						}
+					),
+					item = EwItem(id_item=item.id_item)
+					item.persist()
+			response += "They dropped a slime poudrin!\n"
 
-            item_counter += 1
+			item_counter += 1
 
-    if pleb_dropped:
-        item_counter = 0
+	if pleb_dropped:
+		item_counter = 0
 
-        while item_counter < pleb_amount:
-            items = []
+		while item_counter < pleb_amount:
+			items = []
 
-            for cosmetic in cosmetics_list:
-                if cosmetic.rarity == ewcfg.rarity_plebeian:
-                    items.append(cosmetic)
+			for cosmetic in cosmetics_list:
+				if cosmetic.rarity == ewcfg.rarity_plebeian:
+					items.append(cosmetic)
 
-            item = items[random.randint(0, len(items) - 1)]
+			item = items[random.randint(0, len(items) - 1)]
 
-            ewitem.item_create(
-                item_type=ewcfg.it_cosmetic,
-                id_user=district_data.name,
-                id_server=district_data.id_server,
-                item_props={
-                    'id_cosmetic': item.id_cosmetic,
-                    'cosmetic_name': item.str_name,
-                    'cosmetic_desc': item.str_desc,
-                    'rarity': item.rarity,
-                    'adorned': 'false'
-                }
-            )
-            response += "They dropped a {item_name}!\n".format(item_name=item.str_name)
+			ewitem.item_create(
+				item_type=ewcfg.it_cosmetic,
+				id_user=district_data.name,
+				id_server=district_data.id_server,
+				item_props={
+					'id_cosmetic': item.id_cosmetic,
+					'cosmetic_name': item.str_name,
+					'cosmetic_desc': item.str_desc,
+					'rarity': item.rarity,
+					'adorned': 'false'
+				}
+			)
+			response += "They dropped a {item_name}!\n".format(item_name=item.str_name)
 
-            item_counter += 1
+			item_counter += 1
 
-    if patrician_dropped:
-        item_counter = 0
+	if patrician_dropped:
+		item_counter = 0
 
-        while item_counter < patrician_amount:
-            items = []
+		while item_counter < patrician_amount:
+			items = []
 
-            for cosmetic in cosmetics_list:
-                if cosmetic.rarity == ewcfg.rarity_patrician:
-                    items.append(cosmetic)
+			for cosmetic in cosmetics_list:
+				if cosmetic.rarity == ewcfg.rarity_patrician:
+					items.append(cosmetic)
 
-            item = items[random.randint(0, len(items) - 1)]
+			item = items[random.randint(0, len(items) - 1)]
 
-            ewitem.item_create(
-                item_type=ewcfg.it_cosmetic,
-                id_user=district_data.name,
-                id_server=district_data.id_server,
-                item_props={
-                    'id_cosmetic': item.id_cosmetic,
-                    'cosmetic_name': item.str_name,
-                    'cosmetic_desc': item.str_desc,
-                    'rarity': item.rarity,
-                    'adorned': 'false'
-                }
-            )
-            response += "They dropped a {item_name}!\n".format(item_name=item.str_name)
+			ewitem.item_create(
+				item_type=ewcfg.it_cosmetic,
+				id_user=district_data.name,
+				id_server=district_data.id_server,
+				item_props={
+					'id_cosmetic': item.id_cosmetic,
+					'cosmetic_name': item.str_name,
+					'cosmetic_desc': item.str_desc,
+					'rarity': item.rarity,
+					'adorned': 'false'
+				}
+			)
+			response += "They dropped a {item_name}!\n".format(item_name=item.str_name)
 
-            item_counter += 1
+			item_counter += 1
 
-    if crop_dropped:
-        item_counter = 0
+	if crop_dropped:
+		item_counter = 0
 
-        while item_counter < crop_amount:
+		while item_counter < crop_amount:
 
-            vegetable = random.choice(ewcfg.vegetable_list)
+			vegetable = random.choice(ewcfg.vegetable_list)
 
-            ewitem.item_create(
-                id_user=district_data.name,
-                id_server=district_data.id_server,
-                item_type=ewcfg.it_food,
-                item_props={
-                    'id_food': vegetable.id_food,
-                    'food_name': vegetable.str_name,
-                    'food_desc': vegetable.str_desc,
-                    'recover_hunger': vegetable.recover_hunger,
-                    'str_eat': vegetable.str_eat,
-                    'time_expir': time.time() + ewcfg.farm_food_expir
-                }
-            )
-            response += "They dropped a bushel of {vegetable_name}!\n".format(vegetable_name=vegetable.str_name)
+			ewitem.item_create(
+				id_user=district_data.name,
+				id_server=district_data.id_server,
+				item_type=ewcfg.it_food,
+				item_props={
+					'id_food': vegetable.id_food,
+					'food_name': vegetable.str_name,
+					'food_desc': vegetable.str_desc,
+					'recover_hunger': vegetable.recover_hunger,
+					'str_eat': vegetable.str_eat,
+					'time_expir': time.time() + ewcfg.farm_food_expir
+				}
+			)
+			response += "They dropped a bushel of {vegetable_name}!\n".format(vegetable_name=vegetable.str_name)
 
-            item_counter += 1
+			item_counter += 1
 
-    # Drop dinoslime meat
-    if meat_dropped:
-        meat = None
-        item_counter = 0
+	# Drop dinoslime meat
+	if meat_dropped:
+		meat = None
+		item_counter = 0
 
-        for food in ewcfg.food_list:
-            if food.id_food == ewcfg.item_id_dinoslimemeat:
-                meat = food
-                
-        while item_counter < meat_amount:  
-            ewitem.item_create(
-                id_user=district_data.name,
-                id_server=district_data.id_server,
-                item_type=ewcfg.it_food,
-                item_props={
-                    'id_food': meat.id_food,
-                    'food_name': meat.str_name,
-                    'food_desc': meat.str_desc,
-                    'recover_hunger': meat.recover_hunger,
-                    'str_eat': meat.str_eat,
-                    'time_expir': time.time() + ewcfg.std_food_expir
-                }
-            )
-            response += "They dropped a piece of meat!\n"
-            
-            item_counter += 1
-    
-    # Drop trading cards
-    if card_dropped:
-        cards = None
-        item_counter = 0
-        
-        for item in ewcfg.item_list:
-            if item.id_item == ewcfg.item_id_tradingcardpack:
-                cards = item
+		for food in ewcfg.food_list:
+			if food.id_food == ewcfg.item_id_dinoslimemeat:
+				meat = food
+				
+		while item_counter < meat_amount:  
+			ewitem.item_create(
+				id_user=district_data.name,
+				id_server=district_data.id_server,
+				item_type=ewcfg.it_food,
+				item_props={
+					'id_food': meat.id_food,
+					'food_name': meat.str_name,
+					'food_desc': meat.str_desc,
+					'recover_hunger': meat.recover_hunger,
+					'str_eat': meat.str_eat,
+					'time_expir': time.time() + ewcfg.std_food_expir
+				}
+			)
+			response += "They dropped a piece of meat!\n"
+			
+			item_counter += 1
+	
+	# Drop trading cards
+	if card_dropped:
+		cards = None
+		item_counter = 0
+		
+		for item in ewcfg.item_list:
+			if item.id_item == ewcfg.item_id_tradingcardpack:
+				cards = item
 
-        while item_counter < card_amount:
-            ewitem.item_create(
-                id_user=district_data.name,
-                id_server=district_data.id_server,
-                item_type=ewcfg.it_item,
-                item_props={
-                    'id_item': cards.id_item,
-                    'context': cards.context,
-                    'item_name': cards.str_name,
-                    'item_desc': cards.str_desc,
-                }
-            )
-            response += "They dropped a pack of trading cards!\n"
-            
-            item_counter += 1
+		while item_counter < card_amount:
+			ewitem.item_create(
+				id_user=district_data.name,
+				id_server=district_data.id_server,
+				item_type=ewcfg.it_item,
+				item_props={
+					'id_item': cards.id_item,
+					'context': cards.context,
+					'item_name': cards.str_name,
+					'item_desc': cards.str_desc,
+				}
+			)
+			response += "They dropped a pack of trading cards!\n"
+			
+			item_counter += 1
 
-    if not poudrin_dropped and not pleb_dropped and not patrician_dropped and not crop_dropped and not meat_dropped and not card_dropped:
-        response = "They didn't drop anything...\n"
+	if not poudrin_dropped and not pleb_dropped and not patrician_dropped and not crop_dropped and not meat_dropped and not card_dropped:
+		response = "They didn't drop anything...\n"
 
-    return response
+	return response
 
 # Determines what level an enemy is based on their slime count.
 def level_byslime(slime):
-    return int(abs(slime) ** 0.25)
+	return int(abs(slime) ** 0.25)
 
 # Reskinned version of weapon class from ewwep.
 class EwAttackType:
 
-    # An name used to identify the attacking type
-    id_type = ""
+	# An name used to identify the attacking type
+	id_type = ""
 
-    # Displayed when this weapon is used for a !kill
-    str_kill = ""
+	# Displayed when this weapon is used for a !kill
+	str_kill = ""
 
-    # Displayed to the dead victim in the sewers. Brief phrase such as "gunned down" etc.
-    str_killdescriptor = ""
+	# Displayed to the dead victim in the sewers. Brief phrase such as "gunned down" etc.
+	str_killdescriptor = ""
 
-    # Displayed when viewing the !trauma of another player.
-    str_trauma = ""
+	# Displayed when viewing the !trauma of another player.
+	str_trauma = ""
 
-    # Displayed when viewing the !trauma of yourself.
-    str_trauma_self = ""
+	# Displayed when viewing the !trauma of yourself.
+	str_trauma_self = ""
 
-    # Displayed when a non-lethal hit occurs.
-    str_damage = ""
+	# Displayed when a non-lethal hit occurs.
+	str_damage = ""
 
-    # Displayed when an attack backfires
-    str_backfire = ""
+	# Displayed when an attack backfires
+	str_backfire = ""
 
-    # Function that applies the special effect for this weapon.
-    fn_effect = None
+	# Function that applies the special effect for this weapon.
+	fn_effect = None
 
-    # Displayed when a weapon effect causes a critical hit.
-    str_crit = ""
+	# Displayed when a weapon effect causes a critical hit.
+	str_crit = ""
 
-    # Displayed when a weapon effect causes a miss.
-    str_miss = ""
+	# Displayed when a weapon effect causes a miss.
+	str_miss = ""
 
-    def __init__(
-            self,
-            id_type="",
-            str_kill="",
-            str_killdescriptor="",
-            str_trauma="",
-            str_trauma_self="",
-            str_damage="",
-            fn_effect=None,
-            str_crit="",
-            str_miss="",
-            str_backfire = "",
-    ):
-        self.id_type = id_type
-        self.str_kill = str_kill
-        self.str_killdescriptor = str_killdescriptor
-        self.str_trauma = str_trauma
-        self.str_trauma_self = str_trauma_self
-        self.str_damage = str_damage
-        self.str_backfire = str_backfire
-        self.fn_effect = fn_effect
-        self.str_crit = str_crit
-        self.str_miss = str_miss
-        
+	def __init__(
+			self,
+			id_type="",
+			str_kill="",
+			str_killdescriptor="",
+			str_trauma="",
+			str_trauma_self="",
+			str_damage="",
+			fn_effect=None,
+			str_crit="",
+			str_miss="",
+			str_backfire = "",
+	):
+		self.id_type = id_type
+		self.str_kill = str_kill
+		self.str_killdescriptor = str_killdescriptor
+		self.str_trauma = str_trauma
+		self.str_trauma_self = str_trauma_self
+		self.str_damage = str_damage
+		self.str_backfire = str_backfire
+		self.fn_effect = fn_effect
+		self.str_crit = str_crit
+		self.str_miss = str_miss
+		
 
 # Check if an enemy is dead. Implemented to prevent enemy data from being recreated when not necessary.
 def check_death(enemy_data):
-    if enemy_data.slimes <= 0 or enemy_data.life_state == ewcfg.enemy_lifestate_dead:
-        # delete_enemy(enemy_data)
-        return True
-    else:
-        return False
+	if enemy_data.slimes <= 0 or enemy_data.life_state == ewcfg.enemy_lifestate_dead:
+		# delete_enemy(enemy_data)
+		return True
+	else:
+		return False
 
 # Assigns enemies most of their necessary attributes based on their type.
 def get_enemy_data(enemy_type):
-    enemy = EwEnemy()
-    
-    rare_status = 0
-    if random.randrange(10) == 0:
-       rare_status = 1
+	enemy = EwEnemy()
+	
+	rare_status = 0
+	if random.randrange(10) == 0:
+	   rare_status = 1
 
-    enemy.id_server = ""
-    enemy.slimes = get_enemy_slime(enemy_type)
-    enemy.totaldamage = 0
-    enemy.level = 0
-    enemy.life_state = ewcfg.enemy_lifestate_alive
-    enemy.enemytype = enemy_type
-    enemy.bleed_storage = 0
-    enemy.time_lastenter = 0
-    enemy.initialslimes = 0
-    enemy.id_target = ""
-    enemy.raidtimer = 0
-    enemy.rare_status = rare_status
+	enemy.id_server = ""
+	enemy.slimes = get_enemy_slime(enemy_type)
+	enemy.totaldamage = 0
+	enemy.level = 0
+	enemy.life_state = ewcfg.enemy_lifestate_alive
+	enemy.enemytype = enemy_type
+	enemy.bleed_storage = 0
+	enemy.time_lastenter = 0
+	enemy.initialslimes = 0
+	enemy.id_target = ""
+	enemy.raidtimer = 0
+	enemy.rare_status = rare_status
 
-    # Normal enemies
-    if enemy_type == ewcfg.enemy_type_juvie:
-        enemy.ai = ewcfg.enemy_ai_coward
-        enemy.display_name = ewcfg.enemy_displayname_juvie
-        enemy.attacktype = ewcfg.enemy_attacktype_unarmed
+	# Normal enemies
+	if enemy_type == ewcfg.enemy_type_juvie:
+		enemy.ai = ewcfg.enemy_ai_coward
+		enemy.display_name = ewcfg.enemy_displayname_juvie
+		enemy.attacktype = ewcfg.enemy_attacktype_unarmed
 
-    elif enemy_type == ewcfg.enemy_type_microslime:
-        enemy.ai = ewcfg.enemy_ai_defender
-        enemy.display_name = ewcfg.enemy_displayname_microslime
-        enemy.attacktype = ewcfg.enemy_attacktype_unarmed
+	elif enemy_type == ewcfg.enemy_type_microslime:
+		enemy.ai = ewcfg.enemy_ai_defender
+		enemy.display_name = ewcfg.enemy_displayname_microslime
+		enemy.attacktype = ewcfg.enemy_attacktype_unarmed
 
-    elif enemy_type == ewcfg.enemy_type_dinoslime:
-        enemy.ai = ewcfg.enemy_ai_attacker_a
-        enemy.display_name = ewcfg.enemy_displayname_dinoslime
-        enemy.attacktype = ewcfg.enemy_attacktype_fangs
+	elif enemy_type == ewcfg.enemy_type_dinoslime:
+		enemy.ai = ewcfg.enemy_ai_attacker_a
+		enemy.display_name = ewcfg.enemy_displayname_dinoslime
+		enemy.attacktype = ewcfg.enemy_attacktype_fangs
 
-    elif enemy_type == ewcfg.enemy_type_slimeadactyl:
-        enemy.ai = ewcfg.enemy_ai_attacker_b
-        enemy.display_name = ewcfg.enemy_displayname_slimeadactyl
-        enemy.attacktype = ewcfg.enemy_attacktype_talons
+	elif enemy_type == ewcfg.enemy_type_slimeadactyl:
+		enemy.ai = ewcfg.enemy_ai_attacker_b
+		enemy.display_name = ewcfg.enemy_displayname_slimeadactyl
+		enemy.attacktype = ewcfg.enemy_attacktype_talons
 
-    elif enemy_type == ewcfg.enemy_type_desertraider:
-        enemy.ai = ewcfg.enemy_ai_attacker_b
-        enemy.display_name = ewcfg.enemy_displayname_desertraider
-        enemy.attacktype = ewcfg.enemy_attacktype_raiderscythe
+	elif enemy_type == ewcfg.enemy_type_desertraider:
+		enemy.ai = ewcfg.enemy_ai_attacker_b
+		enemy.display_name = ewcfg.enemy_displayname_desertraider
+		enemy.attacktype = ewcfg.enemy_attacktype_raiderscythe
 
-    elif enemy_type == ewcfg.enemy_type_mammoslime:
-        enemy.ai = ewcfg.enemy_ai_defender
-        enemy.display_name = ewcfg.enemy_displayname_mammoslime
-        enemy.attacktype = ewcfg.enemy_attacktype_tusks
+	elif enemy_type == ewcfg.enemy_type_mammoslime:
+		enemy.ai = ewcfg.enemy_ai_defender
+		enemy.display_name = ewcfg.enemy_displayname_mammoslime
+		enemy.attacktype = ewcfg.enemy_attacktype_tusks
 
-    # Raid bosses
-    elif enemy_type == ewcfg.enemy_type_megaslime:
-        enemy.ai = ewcfg.enemy_ai_attacker_a
-        enemy.display_name = ewcfg.enemy_displayname_megaslime
-        enemy.attacktype = ewcfg.enemy_attacktype_gunkshot
+	# Raid bosses
+	elif enemy_type == ewcfg.enemy_type_megaslime:
+		enemy.ai = ewcfg.enemy_ai_attacker_a
+		enemy.display_name = ewcfg.enemy_displayname_megaslime
+		enemy.attacktype = ewcfg.enemy_attacktype_gunkshot
 
-    elif enemy_type == ewcfg.enemy_type_slimeasaurusrex:
-        enemy.ai = ewcfg.enemy_ai_attacker_b
-        enemy.display_name = ewcfg.enemy_displayname_slimeasaurusrex
-        enemy.attacktype = ewcfg.enemy_attacktype_fangs
-        
-    elif enemy_type == ewcfg.enemy_type_greeneyesslimedragon:
-        enemy.ai = ewcfg.enemy_ai_attacker_a
-        enemy.display_name = ewcfg.enemy_displayname_greeneyesslimedragon
-        enemy.attacktype = ewcfg.enemy_attacktype_molotovbreath
-        
-    elif enemy_type == ewcfg.enemy_type_unnervingfightingoperator:
-        enemy.ai = ewcfg.enemy_ai_attacker_b
-        enemy.display_name = ewcfg.enemy_displayname_unnervingfightingoperator
-        enemy.attacktype = ewcfg.enemy_attacktype_raiderrifle
-        
-    if enemy_type in ewcfg.raid_bosses:
-        enemy.life_state = ewcfg.enemy_lifestate_unactivated
-        enemy.raidtimer = int(time.time())
-        
-    if rare_status == 1:
-        enemy.display_name = ewcfg.rare_display_names[enemy.display_name]
-        enemy.slimes *= 2
+	elif enemy_type == ewcfg.enemy_type_slimeasaurusrex:
+		enemy.ai = ewcfg.enemy_ai_attacker_b
+		enemy.display_name = ewcfg.enemy_displayname_slimeasaurusrex
+		enemy.attacktype = ewcfg.enemy_attacktype_fangs
+		
+	elif enemy_type == ewcfg.enemy_type_greeneyesslimedragon:
+		enemy.ai = ewcfg.enemy_ai_attacker_a
+		enemy.display_name = ewcfg.enemy_displayname_greeneyesslimedragon
+		enemy.attacktype = ewcfg.enemy_attacktype_molotovbreath
+		
+	elif enemy_type == ewcfg.enemy_type_unnervingfightingoperator:
+		enemy.ai = ewcfg.enemy_ai_attacker_b
+		enemy.display_name = ewcfg.enemy_displayname_unnervingfightingoperator
+		enemy.attacktype = ewcfg.enemy_attacktype_armcannon
+		
+	if enemy_type in ewcfg.raid_bosses:
+		enemy.life_state = ewcfg.enemy_lifestate_unactivated
+		enemy.raidtimer = int(time.time())
+		
+	if rare_status == 1:
+		enemy.display_name = ewcfg.rare_display_names[enemy.display_name]
+		enemy.slimes *= 2
 
-    return enemy
+	return enemy
 
 # Returns a randomized amount of slime based on enemy type
 def get_enemy_slime(enemy_type):
-    slime = 0
-    minslime = 0
-    maxslime = 0
-    
-    if enemy_type == ewcfg.enemy_type_juvie:
-        minslime = 10000
-        maxslime = 50000
-    elif enemy_type == ewcfg.enemy_type_microslime:
-        minslime = 10000
-        maxslime = 50000
-    elif enemy_type == ewcfg.enemy_type_dinoslime:
-        minslime = 250000
-        maxslime = 500000
-    elif enemy_type == ewcfg.enemy_type_slimeadactyl:
-        minslime = 500000
-        maxslime = 750000
-    elif enemy_type == ewcfg.enemy_type_desertraider:
-        minslime = 250000
-        maxslime = 750000
-    elif enemy_type == ewcfg.enemy_type_mammoslime:
-        minslime = 600000
-        maxslime = 900000
-    elif enemy_type == ewcfg.enemy_type_megaslime:
-        minslime = 1000000
-        maxslime = 1000000
-    elif enemy_type == ewcfg.enemy_type_slimeasaurusrex:
-        minslime = 1000000
-        maxslime = 1500000
-    elif enemy_type == ewcfg.enemy_type_greeneyesslimedragon:
-        minslime = 1250000
-        maxslime = 1750000
-    elif enemy_type ==  ewcfg.enemy_type_unnervingfightingoperator:
-        minslime = 1000000
-        maxslime = 2500000
-    
-    slime = random.randrange(minslime, (maxslime + 1))    
-    return slime
+	slime = 0
+	minslime = 0
+	maxslime = 0
+	
+	if enemy_type == ewcfg.enemy_type_juvie:
+		minslime = 10000
+		maxslime = 50000
+	elif enemy_type == ewcfg.enemy_type_microslime:
+		minslime = 10000
+		maxslime = 50000
+	elif enemy_type == ewcfg.enemy_type_dinoslime:
+		minslime = 250000
+		maxslime = 500000
+	elif enemy_type == ewcfg.enemy_type_slimeadactyl:
+		minslime = 500000
+		maxslime = 750000
+	elif enemy_type == ewcfg.enemy_type_desertraider:
+		minslime = 250000
+		maxslime = 750000
+	elif enemy_type == ewcfg.enemy_type_mammoslime:
+		minslime = 600000
+		maxslime = 900000
+	elif enemy_type == ewcfg.enemy_type_megaslime:
+		minslime = 1000000
+		maxslime = 1000000
+	elif enemy_type == ewcfg.enemy_type_slimeasaurusrex:
+		minslime = 1750000
+		maxslime = 3000000
+	elif enemy_type == ewcfg.enemy_type_greeneyesslimedragon:
+		minslime = 3500000
+		maxslime = 5000000
+	elif enemy_type ==  ewcfg.enemy_type_unnervingfightingoperator:
+		minslime = 1000000
+		maxslime = 3000000
+	
+	slime = random.randrange(minslime, (maxslime + 1))	
+	return slime
 
 # Selects which non-ghost user to attack based on certain parameters.
 def get_target_by_ai(enemy_data):
 
-    target_data = None
+	target_data = None
 
-    time_now = int(time.time())
+	time_now = int(time.time())
 
-    # If a player's time_lastenter is less than this value, it can be attacked.
-    targettimer = time_now - ewcfg.time_enemyaggro
+	# If a player's time_lastenter is less than this value, it can be attacked.
+	targettimer = time_now - ewcfg.time_enemyaggro
+	raidbossaggrotimer = time_now - ewcfg.time_raidbossaggro
 
-    if enemy_data.ai == ewcfg.enemy_ai_defender:
-        if enemy_data.id_target != "":
-            target_data = EwUser(id_user=enemy_data.id_target, id_server=enemy_data.id_server)
+	if enemy_data.ai == ewcfg.enemy_ai_defender:
+		if enemy_data.id_target != "":
+			target_data = EwUser(id_user=enemy_data.id_target, id_server=enemy_data.id_server)
 
-    elif enemy_data.ai == ewcfg.enemy_ai_attacker_a:
-        users = ewutils.execute_sql_query(
-            "SELECT {id_user}, {life_state}, {time_lastenter} FROM users WHERE {poi} = %s AND {id_server} = %s AND {time_lastenter} < {targettimer} AND NOT {life_state} = {life_state_corpse} ORDER BY {time_lastenter} ASC".format(
-                id_user=ewcfg.col_id_user,
-                life_state=ewcfg.col_life_state,
-                time_lastenter=ewcfg.col_time_lastenter,
-                poi=ewcfg.col_poi,
-                id_server=ewcfg.col_id_server,
-                targettimer=targettimer,
-                life_state_corpse=ewcfg.life_state_corpse
-            ), (
-                enemy_data.poi,
-                enemy_data.id_server
-            ))
-        if len(users) > 0:
-            target_data = EwUser(id_user=users[0][0], id_server=enemy_data.id_server)
+	elif enemy_data.ai == ewcfg.enemy_ai_attacker_a:
+		users = ewutils.execute_sql_query(
+			"SELECT {id_user}, {life_state}, {time_lastenter} FROM users WHERE {poi} = %s AND {id_server} = %s AND {time_lastenter} < {targettimer} AND NOT ({life_state} = {life_state_corpse} OR {life_state} = {life_state_kingpin}) ORDER BY {time_lastenter} ASC".format(
+				id_user=ewcfg.col_id_user,
+				life_state=ewcfg.col_life_state,
+				time_lastenter=ewcfg.col_time_lastenter,
+				poi=ewcfg.col_poi,
+				id_server=ewcfg.col_id_server,
+				targettimer=targettimer,
+				life_state_corpse=ewcfg.life_state_corpse,
+				life_state_kingpin=ewcfg.life_state_kingpin,
+			), (
+				enemy_data.poi,
+				enemy_data.id_server
+			))
+		if len(users) > 0:
+			target_data = EwUser(id_user=users[0][0], id_server=enemy_data.id_server)
 
-    elif enemy_data.ai == ewcfg.enemy_ai_attacker_b:
-        users = ewutils.execute_sql_query(
-            "SELECT {id_user}, {life_state}, {slimes} FROM users WHERE {poi} = %s AND {id_server} = %s AND {time_lastenter} < {targettimer} AND NOT {life_state} = {life_state_corpse} ORDER BY {slimes} DESC".format(
-                id_user=ewcfg.col_id_user,
-                life_state=ewcfg.col_life_state,
-                slimes=ewcfg.col_slimes,
-                poi=ewcfg.col_poi,
-                id_server=ewcfg.col_id_server,
-                time_lastenter=ewcfg.col_time_lastenter,
-                targettimer=targettimer,
-                life_state_corpse=ewcfg.life_state_corpse
-            ), (
-                enemy_data.poi,
-                enemy_data.id_server
-            ))
-        if len(users) > 0:
-            target_data = EwUser(id_user=users[0][0], id_server=enemy_data.id_server)
+	elif enemy_data.ai == ewcfg.enemy_ai_attacker_b:
+		users = ewutils.execute_sql_query(
+			"SELECT {id_user}, {life_state}, {slimes} FROM users WHERE {poi} = %s AND {id_server} = %s AND {time_lastenter} < {targettimer} AND NOT ({life_state} = {life_state_corpse} OR {life_state} = {life_state_kingpin}) ORDER BY {slimes} DESC".format(
+				id_user=ewcfg.col_id_user,
+				life_state=ewcfg.col_life_state,
+				slimes=ewcfg.col_slimes,
+				poi=ewcfg.col_poi,
+				id_server=ewcfg.col_id_server,
+				time_lastenter=ewcfg.col_time_lastenter,
+				targettimer=targettimer,
+				life_state_corpse=ewcfg.life_state_corpse,
+				life_state_kingpin=ewcfg.life_state_kingpin,
+			), (
+				enemy_data.poi,
+				enemy_data.id_server
+			))
+		if len(users) > 0:
+			target_data = EwUser(id_user=users[0][0], id_server=enemy_data.id_server)
+			
+	# If an enemy is a raidboss, don't let it attack until 3 seconds have passed when entering a new district.
+	if enemy_data.enemytype in ewcfg.raid_bosses and enemy_data.time_lastenter > raidbossaggrotimer:
+		target_data = None
 
-    return target_data
+	return target_data
 
 # Check if raidboss is ready to attack / be attacked
 def check_raidboss_countdown(enemy_data):
-    time_now = int(time.time())
+	time_now = int(time.time())
 
-    # Wait for raid bosses
-    if enemy_data.enemytype in ewcfg.raid_bosses and enemy_data.raidtimer <= time_now - ewcfg.time_raidcountdown:
-        # Raid boss has activated!
-        return True
-    elif enemy_data.enemytype in ewcfg.raid_bosses and enemy_data.raidtimer > time_now - ewcfg.time_raidcountdown:
-        # Raid boss hasn't activated.
-        return False
+	# Wait for raid bosses
+	if enemy_data.enemytype in ewcfg.raid_bosses and enemy_data.raidtimer <= time_now - ewcfg.time_raidcountdown:
+		# Raid boss has activated!
+		return True
+	elif enemy_data.enemytype in ewcfg.raid_bosses and enemy_data.raidtimer > time_now - ewcfg.time_raidcountdown:
+		# Raid boss hasn't activated.
+		return False
 
 def check_raidboss_movecooldown(enemy_data):
-    time_now = int(time.time())
+	time_now = int(time.time())
 
-    if enemy_data.enemytype in ewcfg.raid_bosses and enemy_data.time_lastenter <= time_now - ewcfg.time_raidboss_movecooldown:
-        # Raid boss can move
-        return True
-    elif enemy_data.enemytype in ewcfg.raid_bosses and enemy_data.time_lastenter > time_now - ewcfg.time_raidboss_movecooldown:
-        # Raid boss can't move yet
-        return False
+	if enemy_data.enemytype in ewcfg.raid_bosses and enemy_data.time_lastenter <= time_now - ewcfg.time_raidboss_movecooldown:
+		# Raid boss can move
+		return True
+	elif enemy_data.enemytype in ewcfg.raid_bosses and enemy_data.time_lastenter > time_now - ewcfg.time_raidboss_movecooldown:
+		# Raid boss can't move yet
+		return False
 
 # Gives enemy an identifier so it's easier to pick out in a crowd of enemies
 def set_identifier(poi, id_server):
-    district = EwDistrict(district=poi, id_server=id_server)
-    enemies_list = district.get_enemies_in_district()
+	district = EwDistrict(district=poi, id_server=id_server)
+	enemies_list = district.get_enemies_in_district()
 
-    # A list of identifiers from enemies in a district
-    enemy_identifiers = []
+	# A list of identifiers from enemies in a district
+	enemy_identifiers = []
 
-    new_identifier = ewcfg.identifier_letters[0]
+	new_identifier = ewcfg.identifier_letters[0]
 
-    if len(enemies_list) > 0:
-        for enemy_id in enemies_list:
-            enemy = EwEnemy(id_enemy=enemy_id)
-            enemy_identifiers.append(enemy.identifier)
+	if len(enemies_list) > 0:
+		for enemy_id in enemies_list:
+			enemy = EwEnemy(id_enemy=enemy_id)
+			enemy_identifiers.append(enemy.identifier)
 
-        # Sort the list of identifiers alphabetically
-        enemy_identifiers.sort()
+		# Sort the list of identifiers alphabetically
+		enemy_identifiers.sort()
 
-        for checked_enemy_identifier in enemy_identifiers:
-            # If the new identifier matches one from the list of enemy identifiers, give it the next applicable letter
-            # Repeat until a unique identifier is given
-            if new_identifier == checked_enemy_identifier:
-                next_letter = (ewcfg.identifier_letters.index(checked_enemy_identifier) + 1)
-                new_identifier = ewcfg.identifier_letters[next_letter]
-            else:
-                continue
+		for checked_enemy_identifier in enemy_identifiers:
+			# If the new identifier matches one from the list of enemy identifiers, give it the next applicable letter
+			# Repeat until a unique identifier is given
+			if new_identifier == checked_enemy_identifier:
+				next_letter = (ewcfg.identifier_letters.index(checked_enemy_identifier) + 1)
+				new_identifier = ewcfg.identifier_letters[next_letter]
+			else:
+				continue
 
-    return new_identifier
+	return new_identifier
 
 

--- a/ewjuviecmd.py
+++ b/ewjuviecmd.py
@@ -701,3 +701,24 @@ def get_cell_symbol(cell):
 	else:
 		cell_str = "X"
 	return cell_str
+
+async def crush(cmd):
+	member = cmd.message.author
+	user_data = EwUser(member=member)
+	response = ""
+	
+	poudrin = ewitem.find_item(item_search="slimepoudrin", id_user=cmd.message.author.id, id_server=cmd.message.server.id if cmd.message.server is not None else None)
+	
+	if poudrin is None:
+		response = "You need a slime poudrin."
+	else:
+		# delete a slime poudrin from the player's inventory
+		ewitem.item_delete(id_item=poudrin.get('id_item'))
+		
+		user_data.slimes += ewcfg.crush_slimes
+		user_data.persist()
+		
+		response = "You crush the hardened slime crystal with your bare hands.\nYou gain 10,000 slime. Sick, dude!!"
+		
+	# Send the response to the player.
+	await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))

--- a/ewmap.py
+++ b/ewmap.py
@@ -125,6 +125,8 @@ class EwPoi:
 	# which transport lines stop here
 	transport_lines = set()
 
+	# if this zone belongs to the outskirts
+	is_outskirts = False
 
 	def __init__(
 		self,
@@ -153,7 +155,8 @@ class EwPoi:
 		default_line = "",
 		default_stop = "",
 		is_transport_stop = False,
-		transport_lines = None
+		transport_lines = None,
+		is_outskirts = False
 	):
 		self.id_poi = id_poi
 		self.alias = alias
@@ -181,6 +184,7 @@ class EwPoi:
 		self.default_stop = default_stop
 		self.is_transport_stop = is_transport_stop
 		self.transport_lines = transport_lines
+		self.is_outskirts = is_outskirts
 
 # New map as of 7/19/19
 

--- a/ewutils.py
+++ b/ewutils.py
@@ -1217,3 +1217,7 @@ async def explode(damage = 0, district_data = None):
 def is_otp(user_data):
 	return user_data.poi not in [ewcfg.poi_id_thesewers, ewcfg.poi_id_juviesrow, ewcfg.poi_id_copkilltown, ewcfg.poi_id_rowdyroughhouse]
 
+async def delete_last_message(client, last_messages, tick_length):
+	await asyncio.sleep(tick_length)
+	await client.delete_message(last_messages[len(last_messages) - 1])
+

--- a/ewwep.py
+++ b/ewwep.py
@@ -1980,6 +1980,12 @@ async def attackEnemy(cmd, user_data, weapon, resp_cont, weapon_item, slimeoid, 
 					damage=damage
 				)
 
+				if enemy_data.ai == ewcfg.enemy_ai_coward:
+					response += random.choice(ewcfg.coward_responses_hurt)
+				elif enemy_data.ai == ewcfg.enemy_ai_defender:
+					enemy_data.id_target = user_data.id_user
+					enemy_data.persist()
+
 			if ewcfg.weapon_class_ammo in weapon.classes and weapon_item.item_props.get("ammo") == 0:
 				response += "\n" + weapon.str_reload_warning.format(
 					name_player=cmd.message.author.display_name)
@@ -1992,6 +1998,12 @@ async def attackEnemy(cmd, user_data, weapon, resp_cont, weapon_item, slimeoid, 
 					target_name=enemy_data.display_name,
 					damage=damage
 				)
+
+				if enemy_data.ai == ewcfg.enemy_ai_coward:
+					response += random.choice(ewcfg.coward_responses_hurt).format(enemy_data.display_name)
+				elif enemy_data.ai == ewcfg.enemy_ai_defender:
+					enemy_data.id_target = user_data.id_user
+					enemy_data.persist()
 
 		resp_cont.add_channel_response(cmd.message.channel.name, response)
 
@@ -2011,8 +2023,8 @@ async def attackEnemy(cmd, user_data, weapon, resp_cont, weapon_item, slimeoid, 
 	if was_killed and enemy_data.enemytype in ewcfg.raid_bosses:
 		# announce raid boss kill in kill feed channel
 
-		killfeed_resp = "*{}*: {}\n\n".format(cmd.message.author.display_name, old_response)
-		killfeed_resp += "`-------------------------`"
+		killfeed_resp = "*{}*: {}\n".format(cmd.message.author.display_name, old_response)
+		killfeed_resp += "`-------------------------`{}".format(ewcfg.emote_megaslime)
 
 		killfeed_resp_cont = ewutils.EwResponseContainer(id_server=cmd.message.server.id)
 		killfeed_resp_cont.add_channel_response(ewcfg.channel_killfeed, killfeed_resp)


### PR DESCRIPTION
- Enemies with defender AI (Microslime, Mammoslime) now function as intended.
- All raid bosses except megaslime have been buffed, but made less common to compensate.
- Made Dinoslime and Slimeadactyl have a lower minimum poudrin drop amount.
- Added !crushpoudrin. Crush a poudrin to gain 10,000 slime instantly.
- Raid bosses will wait three seconds to attack a player when entering a new district.