### PR TITLE
Duels, Dances, and Swears

### DIFF
--- a/README
+++ b/README
@@ -31,6 +31,7 @@ CREATE TABLE users (
 	life_state int NOT NULL DEFAULT '1',
 	busted int NOT NULL DEFAULT '0',
 	rr_challenger_id varchar(128) NOT NULL DEFAULT '',
+	rr_restriction int NOT NULL DEFAULT '0',
 	time_last_action bigint NOT NULL DEFAULT '0',
 	weaponmarried int NOT NULL DEFAULT '0',
 	time_lastscavenge int NOT NULL DEFAULT '0',
@@ -55,6 +56,7 @@ CREATE TABLE users (
 	festivity_from_slimecoin int NOT NULL DEFAULT '0',
 	slimernalia_kingpin boolean NOT NULL DEFAULT false,
 	manuscript int NOT NULL DEFAULT '-1',
+	swear_jar bigint NOT NULL DEFAULT '0',
 
 	CONSTRAINT id_user_server PRIMARY KEY (id_user, id_server)
 );

--- a/README
+++ b/README
@@ -30,8 +30,6 @@ CREATE TABLE users (
 	poi varchar(64) NOT NULL default 'classroom',
 	life_state int NOT NULL DEFAULT '1',
 	busted int NOT NULL DEFAULT '0',
-	rr_challenger_id varchar(128) NOT NULL DEFAULT '',
-	rr_restriction int NOT NULL DEFAULT '0',
 	time_last_action bigint NOT NULL DEFAULT '0',
 	weaponmarried int NOT NULL DEFAULT '0',
 	time_lastscavenge int NOT NULL DEFAULT '0',

--- a/client.py
+++ b/client.py
@@ -84,6 +84,7 @@ cmd_map = {
 	ewcfg.cmd_shoot_alt2: ewwep.attack,
 	ewcfg.cmd_shoot_alt3: ewwep.attack,
 	ewcfg.cmd_shoot_alt4: ewwep.attack,
+	ewcfg.cmd_shoot_alt5: ewwep.attack,
 	ewcfg.cmd_attack: ewwep.attack,
 
 	# Reload
@@ -289,6 +290,9 @@ cmd_map = {
 	ewcfg.cmd_russian: ewcasino.russian_roulette,
 	ewcfg.cmd_accept: ewcmd.accept,
 	ewcfg.cmd_refuse: ewcmd.refuse,
+	
+	# Dueling
+	ewcfg.cmd_duel: ewcasino.duel,
 
 
 	# See what's for sale in the Food Court.

--- a/client.py
+++ b/client.py
@@ -1183,6 +1183,15 @@ async def on_message(message):
 			response = "You manage to break {}'s garrote wire!".format(source.display_name)
 			user_data.clear_status(ewcfg.status_strangled_id)			
 			return await ewutils.send_message(client, message.channel, ewutils.formatMessage(message.author, response))
+		
+		if ewutils.active_restrictions.get(user_data.id_user) == 3:
+			die_resp = user_data.die(cause=ewcfg.cause_praying)
+			user_data.persist()
+			await ewrolemgr.updateRoles(client=client, member=message.author)
+			await die_resp.post()
+
+			response = "ENDLESS WAR completely and utterly obliterates {} with a bone-hurting beam.".format(message.author.display_name).replace("@", "\{at\}")
+			return await ewutils.send_message(client, message.channel, response)
 
 	if message.content.startswith(ewcfg.cmd_prefix) or message.server == None or len(message.author.roles) < 2 or (any(swear in ewutils.flattenTokenListToString(content_tolower) for swear in ewcfg.curse_words)):
 		"""
@@ -1235,7 +1244,7 @@ async def on_message(message):
 				usermodel.slimecoin = max(0, usermodel.slimecoin - 1000000000) # 1 billion slimecoin fine for swearing
 				usermodel.persist()
 			
-			response = 'ENDLESS WAR judges you harshly!\n"{}"'.format(random.choice(ewcfg.curse_responses))
+			response = 'ENDLESS WAR judges you harshly!\n"**{}**"'.format(random.choice(ewcfg.curse_responses).upper())
 			await ewutils.send_message(client, message.channel, response)
 			
 			# if the message wasn't a command, we can stop here

--- a/client.py
+++ b/client.py
@@ -1235,7 +1235,7 @@ async def on_message(message):
 				usermodel.slimecoin = max(0, usermodel.slimecoin - 1000000000) # 1 billion slimecoin fine for swearing
 				usermodel.persist()
 			
-			response = 'ENDLESS WAR judges you harshly!\n"{}"\n\n'.format(random.choice(ewcfg.curse_responses))
+			response = 'ENDLESS WAR judges you harshly!\n"{}"'.format(random.choice(ewcfg.curse_responses))
 			await ewutils.send_message(client, message.channel, response)
 			
 			# if the message wasn't a command, we can stop here

--- a/ew.py
+++ b/ew.py
@@ -37,6 +37,7 @@ class EwUser:
 	life_state = 0
 	busted = False
 	rr_challenger = ""
+	rr_restriction = 0
 	time_last_action = 0
 	weaponmarried = False
 	arrested = False
@@ -49,6 +50,7 @@ class EwUser:
 	festivity_from_slimecoin = 0
 	slimernalia_kingpin = False
 	manuscript = -1
+	swear_jar = 0
 
 	time_lastkill = 0
 	time_lastrevive = 0
@@ -707,7 +709,7 @@ class EwUser:
 				# Retrieve object
 
 
-				cursor.execute("SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} FROM users WHERE id_user = %s AND id_server = %s".format(
+				cursor.execute("SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} FROM users WHERE id_user = %s AND id_server = %s".format(
 
 					ewcfg.col_slimes,
 					ewcfg.col_slimelevel,
@@ -729,6 +731,7 @@ class EwUser:
 					ewcfg.col_life_state,
 					ewcfg.col_busted,
 					ewcfg.col_rrchallenger,
+					ewcfg.col_rr_restriction,
 					ewcfg.col_time_last_action,
 					ewcfg.col_weaponmarried,
 					ewcfg.col_time_lastscavenge,
@@ -753,6 +756,7 @@ class EwUser:
 					ewcfg.col_festivity_from_slimecoin,
 					ewcfg.col_slimernalia_kingpin,
 					ewcfg.col_manuscript,
+					ewcfg.col_swear_jar
 				), (
 					id_user,
 					id_server
@@ -781,30 +785,32 @@ class EwUser:
 					self.life_state = result[17]
 					self.busted = (result[18] == 1)
 					self.rr_challenger = result[19]
-					self.time_last_action = result[20]
-					self.weaponmarried = (result[21] == 1)
-					self.time_lastscavenge = result[22]
-					self.bleed_storage = result[23]
-					self.time_lastenter = result[24]
-					self.time_lastoffline = result[25]
-					self.time_joined = result[26]
-					self.poi_death = result[27]
-					self.slime_donations = result[28]
-					self.poudrin_donations = result[29]
-					self.arrested = (result[30] == 1)
-					self.splattered_slimes = result[31]
-					self.time_expirpvp = result[32]
-					self.time_lastenlist = result[33]
-					self.apt_zone = result[34]
-					self.visiting = result[35]
-					self.active_slimeoid = result[36]
-					self.has_soul = result[37]
-					self.sap = result[38]
-					self.hardened_sap = result[39]
-					self.festivity = result[40]
-					self.festivity_from_slimecoin = result[41]
-					self.slimernalia_kingpin = (result[42] == 1)
-					self.manuscript = result[43]
+					self.rr_restriction = result[20]
+					self.time_last_action = result[21]
+					self.weaponmarried = (result[22] == 1)
+					self.time_lastscavenge = result[23]
+					self.bleed_storage = result[24]
+					self.time_lastenter = result[25]
+					self.time_lastoffline = result[26]
+					self.time_joined = result[27]
+					self.poi_death = result[28]
+					self.slime_donations = result[29]
+					self.poudrin_donations = result[30]
+					self.arrested = (result[31] == 1)
+					self.splattered_slimes = result[32]
+					self.time_expirpvp = result[33]
+					self.time_lastenlist = result[34]
+					self.apt_zone = result[35]
+					self.visiting = result[36]
+					self.active_slimeoid = result[37]
+					self.has_soul = result[38]
+					self.sap = result[39]
+					self.hardened_sap = result[40]
+					self.festivity = result[41]
+					self.festivity_from_slimecoin = result[42]
+					self.slimernalia_kingpin = (result[43] == 1)
+					self.manuscript = result[44]
+					self.swear_jar = result[45]
 				else:
 					self.poi = ewcfg.poi_id_tutorial_classroom
 					self.life_state = ewcfg.life_state_juvenile
@@ -860,7 +866,7 @@ class EwUser:
 			self.limit_fix();
 
 			# Save the object.
-			cursor.execute("REPLACE INTO users({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)".format(
+			cursor.execute("REPLACE INTO users({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)".format(
 				ewcfg.col_id_user,
 				ewcfg.col_id_server,
 				ewcfg.col_slimes,
@@ -884,6 +890,7 @@ class EwUser:
 				ewcfg.col_life_state,
 				ewcfg.col_busted,
 				ewcfg.col_rrchallenger,
+				ewcfg.col_rr_restriction,
 				ewcfg.col_time_last_action,
 				ewcfg.col_weaponmarried,
 				ewcfg.col_time_lastscavenge,
@@ -908,6 +915,7 @@ class EwUser:
 				ewcfg.col_festivity_from_slimecoin,
 				ewcfg.col_slimernalia_kingpin,
 				ewcfg.col_manuscript,
+				ewcfg.col_swear_jar,
 			), (
 				self.id_user,
 				self.id_server,
@@ -932,6 +940,7 @@ class EwUser:
 				self.life_state,
 				(1 if self.busted else 0),
 				self.rr_challenger,
+				self.rr_restriction,
 				self.time_last_action,
 				(1 if self.weaponmarried else 0),
 				self.time_lastscavenge,
@@ -956,6 +965,7 @@ class EwUser:
 				self.festivity_from_slimecoin,
 				self.slimernalia_kingpin,
 				self.manuscript,
+				self.swear_jar
 			))
 
 			conn.commit()

--- a/ew.py
+++ b/ew.py
@@ -36,8 +36,6 @@ class EwUser:
 	poi = ""
 	life_state = 0
 	busted = False
-	rr_challenger = ""
-	rr_restriction = 0
 	time_last_action = 0
 	weaponmarried = False
 	arrested = False
@@ -254,6 +252,8 @@ class EwUser:
 		self.sap = 0
 		self.hardened_sap = 0
 		ewutils.moves_active[self.id_user] = 0
+		ewutils.active_target_map[self.id_user] = ""
+		ewutils.active_restrictions[self.id_user] = 0
 		ewstats.clear_on_death(id_server = self.id_server, id_user = self.id_user)
 
 		self.persist()
@@ -709,7 +709,7 @@ class EwUser:
 				# Retrieve object
 
 
-				cursor.execute("SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} FROM users WHERE id_user = %s AND id_server = %s".format(
+				cursor.execute("SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} FROM users WHERE id_user = %s AND id_server = %s".format(
 
 					ewcfg.col_slimes,
 					ewcfg.col_slimelevel,
@@ -730,8 +730,6 @@ class EwUser:
 					ewcfg.col_poi,
 					ewcfg.col_life_state,
 					ewcfg.col_busted,
-					ewcfg.col_rrchallenger,
-					ewcfg.col_rr_restriction,
 					ewcfg.col_time_last_action,
 					ewcfg.col_weaponmarried,
 					ewcfg.col_time_lastscavenge,
@@ -784,33 +782,31 @@ class EwUser:
 					self.poi = result[16]
 					self.life_state = result[17]
 					self.busted = (result[18] == 1)
-					self.rr_challenger = result[19]
-					self.rr_restriction = result[20]
-					self.time_last_action = result[21]
-					self.weaponmarried = (result[22] == 1)
-					self.time_lastscavenge = result[23]
-					self.bleed_storage = result[24]
-					self.time_lastenter = result[25]
-					self.time_lastoffline = result[26]
-					self.time_joined = result[27]
-					self.poi_death = result[28]
-					self.slime_donations = result[29]
-					self.poudrin_donations = result[30]
-					self.arrested = (result[31] == 1)
-					self.splattered_slimes = result[32]
-					self.time_expirpvp = result[33]
-					self.time_lastenlist = result[34]
-					self.apt_zone = result[35]
-					self.visiting = result[36]
-					self.active_slimeoid = result[37]
-					self.has_soul = result[38]
-					self.sap = result[39]
-					self.hardened_sap = result[40]
-					self.festivity = result[41]
-					self.festivity_from_slimecoin = result[42]
-					self.slimernalia_kingpin = (result[43] == 1)
-					self.manuscript = result[44]
-					self.swear_jar = result[45]
+					self.time_last_action = result[19]
+					self.weaponmarried = (result[20] == 1)
+					self.time_lastscavenge = result[21]
+					self.bleed_storage = result[22]
+					self.time_lastenter = result[23]
+					self.time_lastoffline = result[24]
+					self.time_joined = result[25]
+					self.poi_death = result[26]
+					self.slime_donations = result[27]
+					self.poudrin_donations = result[28]
+					self.arrested = (result[29] == 1)
+					self.splattered_slimes = result[30]
+					self.time_expirpvp = result[31]
+					self.time_lastenlist = result[32]
+					self.apt_zone = result[33]
+					self.visiting = result[34]
+					self.active_slimeoid = result[35]
+					self.has_soul = result[36]
+					self.sap = result[37]
+					self.hardened_sap = result[38]
+					self.festivity = result[39]
+					self.festivity_from_slimecoin = result[40]
+					self.slimernalia_kingpin = (result[41] == 1)
+					self.manuscript = result[42]
+					self.swear_jar = result[43]
 				else:
 					self.poi = ewcfg.poi_id_tutorial_classroom
 					self.life_state = ewcfg.life_state_juvenile
@@ -866,7 +862,7 @@ class EwUser:
 			self.limit_fix();
 
 			# Save the object.
-			cursor.execute("REPLACE INTO users({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)".format(
+			cursor.execute("REPLACE INTO users({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)".format(
 				ewcfg.col_id_user,
 				ewcfg.col_id_server,
 				ewcfg.col_slimes,
@@ -889,8 +885,6 @@ class EwUser:
 				ewcfg.col_poi,
 				ewcfg.col_life_state,
 				ewcfg.col_busted,
-				ewcfg.col_rrchallenger,
-				ewcfg.col_rr_restriction,
 				ewcfg.col_time_last_action,
 				ewcfg.col_weaponmarried,
 				ewcfg.col_time_lastscavenge,
@@ -939,8 +933,6 @@ class EwUser:
 				self.poi,
 				self.life_state,
 				(1 if self.busted else 0),
-				self.rr_challenger,
-				self.rr_restriction,
 				self.time_last_action,
 				(1 if self.weaponmarried else 0),
 				self.time_lastscavenge,

--- a/ewapt.py
+++ b/ewapt.py
@@ -312,10 +312,12 @@ async def retire(cmd):
 
 	if ewmap.channel_name_is_poi(cmd.message.channel.name) == False:
 		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, "You must {} in a zone's channel.".format(cmd.tokens[0])))
+	elif user_data.rr_restriction > 0:
+		response = "You can't do that right now."
+		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
 	elif user_data.apt_zone != poi.id_poi:
 		response = "You don't own an apartment here."
 		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
-
 	else:
 		ewmap.move_counter += 1
 		move_current = ewutils.moves_active[cmd.message.author.id] = ewmap.move_counter
@@ -970,6 +972,8 @@ async def knock(cmd = None):
 
 		else:
 			user_data.time_expirpvp = ewutils.calculatePvpTimer(user_data.time_expirpvp, (int(time.time()) + ewcfg.time_pvp_knock))
+			user_data.persist()
+			await ewrolemgr.updateRoles(client=cmd.client, member=cmd.message.author)
 
 			response = "{} is knocking at your door. Do you !accept their arrival, or !refuse entry?".format(cmd.message.author.display_name)
 			try:

--- a/ewapt.py
+++ b/ewapt.py
@@ -312,7 +312,7 @@ async def retire(cmd):
 
 	if ewmap.channel_name_is_poi(cmd.message.channel.name) == False:
 		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, "You must {} in a zone's channel.".format(cmd.tokens[0])))
-	elif user_data.rr_restriction > 0:
+	elif ewutils.active_restrictions.get(user_data.id_user) != None and ewutils.active_restrictions.get(user_data.id_user) > 0:
 		response = "You can't do that right now."
 		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
 	elif user_data.apt_zone != poi.id_poi:
@@ -984,12 +984,11 @@ async def knock(cmd = None):
 			
 			try:
 				accepted = False
-				if user_data.rr_challenger == target_data.apt_zone:
+				if ewutils.active_target_map.get(user_data.id_user) == target_data.apt_zone:
 					return #returns if the user is spam knocking. However, the person in the apt still gets each of the DMs above.
 				else:
 					user_data = EwUser(member=cmd.message.author)
-					user_data.rr_challenger = target_data.apt_zone
-					user_data.persist()
+					ewutils.active_target_map[user_data.id_user] = target_data.apt_zone
 					message = await cmd.client.wait_for_message(timeout=20, author=target, check=ewutils.check_accept_or_refuse)
 
 					if message != None:
@@ -998,16 +997,17 @@ async def knock(cmd = None):
 						if message.content.lower() == ewcfg.cmd_refuse:
 							accepted = False
 					else:
-						user_data = EwUser(member=cmd.message.author)
-						if user_data.rr_challenger != "": #checks if a user is knocking, records the recipient and removes it when done
-							user_data.persist()
+						pass
+						#user_data = EwUser(member=cmd.message.author)
+						#if ewutils.active_target_map.get(user_data.id_user) != "": #checks if a user is knocking, records the recipient and removes it when done
+						#	user_data.persist()
 			except:
 				accepted = False
 			user_data = EwUser(member=cmd.message.author)
 			if accepted:
 				user_data.poi = target_poi.id_poi
 				user_data.visiting = target_data.id_user
-				user_data.rr_challenger = ""
+				ewutils.active_target_map[user_data.id_user] = ""
 				user_data.persist()
 				await ewrolemgr.updateRoles(client=cmd.client, member=cmd.message.author)
 				response = "You arrive in the abode of {}.".format(target.display_name)
@@ -1015,9 +1015,8 @@ async def knock(cmd = None):
 				response = "{} enters your home.".format(cmd.message.author.display_name)
 				return await ewutils.send_message(cmd.client, target, ewutils.formatMessage(target, response))
 			else:
-				if user_data.rr_challenger != "":
-					user_data.rr_challenger = ""
-					user_data.persist()
+				if ewutils.active_target_map.get(user_data.id_user) != "":
+					ewutils.active_target_map[user_data.id_user] = ""
 	elif cmd.mentions_count == 0:
 		response = "Whose door are you knocking?"
 		return await ewutils.send_message(cmd.client, cmd.message.author, ewutils.formatMessage(cmd.message.author, response))
@@ -1090,16 +1089,14 @@ async def trickortreat(cmd = None):
 
 			try:
 				treat = False
-				if user_data.rr_challenger == target_data.apt_zone:
-					# For Double Halloween spam knocking isn't really an issue. Just clear up rr_challenger for now.
+				if ewutils.active_target_map.get(user_data.id_user) == target_data.apt_zone:
+					# For Double Halloween spam knocking isn't really an issue. Just clear up their slot in the active target map for now.
 					print('DEBUG: Spam knock in trickortreat command.')
-					user_data.rr_challenger = ""
-					user_data.persist()
+					ewutils.active_target_map[user_data.id_user] = ""
 					return #returns if the user is spam knocking. However, the person in the apt still gets each of the DMs above.
 				else:
 					user_data = EwUser(member=cmd.message.author)
-					user_data.rr_challenger = target_data.apt_zone
-					user_data.persist()
+					ewutils.active_target_map[user_data.id_user] = target_data.apt_zone
 					message = await cmd.client.wait_for_message(timeout=20, author=target, check=ewutils.check_trick_or_treat)
 
 					if message != None:
@@ -1109,9 +1106,9 @@ async def trickortreat(cmd = None):
 							treat = False
 					else:
 						reject = True
-						user_data = EwUser(member=cmd.message.author)
-						if user_data.rr_challenger != "": #checks if a user is knocking, records the recipient and removes it when done
-							user_data.persist()
+						#user_data = EwUser(member=cmd.message.author)
+						#if ewutils.active_target_map.get(user_data.id_user) != "": #checks if a user is knocking, records the recipient and removes it when done
+						#	user_data.persist()
 			except:
 				reject = True
 			user_data = EwUser(member=cmd.message.author)
@@ -1127,8 +1124,7 @@ async def trickortreat(cmd = None):
 			user_data.persist()
 			
 			if treat:
-				user_data.rr_challenger = ""
-				user_data.persist()
+				ewutils.active_target_map[user_data.id_user] = ""
 				
 				item = random.choice(ewcfg.trickortreat_results)
 				item_props = ewitem.gen_item_props(item)
@@ -1157,8 +1153,8 @@ async def trickortreat(cmd = None):
 				else:
 					trick_index = 3
 					
-				if user_data.rr_challenger != "":
-					user_data.rr_challenger = ""
+				if ewutils.active_target_map.get(user_data.id_user) != None and ewutils.active_target_map.get(user_data.id_user) != "":
+					ewutils.active_target_map[user_data.id_user] = ""
 				user_data.change_slimes(n = -slime_loss, source=ewcfg.source_damage)
 				if user_data.slimes <= 0:
 					client = ewutils.get_client()

--- a/ewcasino.py
+++ b/ewcasino.py
@@ -1178,11 +1178,11 @@ async def russian_roulette(cmd):
 	challengee = EwUser(member = member)
 
 	#Players have been challenged
-	if challenger.rr_challenger != "":
+	if ewutils.active_target_map.get(challenger.id_user) != None and ewutils.active_target_map.get(challenger.id_user) != "":
 		response = "You are already in the middle of a challenge."
 		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
 
-	if challengee.rr_challenger != "":
+	if ewutils.active_target_map.get(challengee.id_user) != None and ewutils.active_target_map.get(challengee.id_user) != "":
 		response = "{} is already in the middle of a challenge.".format(member.display_name).replace("@", "\{at\}")
 		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
 
@@ -1197,24 +1197,25 @@ async def russian_roulette(cmd):
 		if challenger.life_state == ewcfg.life_state_corpse:
 			response = "You try to grab the gun, but it falls through your hands. Ghosts can't hold weapons.".format(author.display_name).replace("@", "\{at\}")
 			return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
-
 		elif challengee.life_state == ewcfg.life_state_corpse:
 			response = "{} tries to grab the gun, but it falls through their hands. Ghosts can't hold weapons.".format(member.display_name).replace("@", "\{at\}")
 			return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
-
+		elif challenger.life_state == ewcfg.life_state_kingpin:
+			response = "Throwing all of your gang's hard earned slime on the line strikes you as a bad idea..."
+			return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
+		elif challengee.life_state == ewcfg.life_state_kingpin:
+			response = "They think about accepting for a moment, but then back away, remembering all the hard work their gangsters have put forth. Bummer..."
+			return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
 		else:
 			response = "Juveniles are too cowardly to gamble their lives."
 			return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
 
 	#Assign a challenger so players can't be challenged
-	challenger.rr_challenger = challenger.id_user
-	challengee.rr_challenger = challenger.id_user
+	ewutils.active_target_map[challenger.id_user] = challengee.id_user
+	ewutils.active_target_map[challengee.id_user] = challenger.id_user
 	
-	challenger.rr_restriction = 1
-	challengee.rr_restriction = 1
-
-	challenger.persist()
-	challengee.persist()
+	ewutils.active_restrictions[challenger.id_user] = 1
+	ewutils.active_restrictions[challengee.id_user] = 1
 
 	response = "You have been challenged by {} to a game of russian roulette. Do you !accept or !refuse?".format(author.display_name).replace("@", "\{at\}")
 	await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(member, response))
@@ -1284,11 +1285,11 @@ async def russian_roulette(cmd):
 					challengee.id_killer = challengee.id_user
 					challengee.die(cause = ewcfg.cause_suicide)
 					
-				challenger.rr_challenger = ""
-				challengee.rr_challenger = ""
+				ewutils.active_target_map[challenger.id_user] = ""
+				ewutils.active_target_map[challengee.id_user] = ""
 
-				challenger.rr_restriction = 0
-				challengee.rr_restriction = 0
+				ewutils.active_restrictions[challenger.id_user] = 0
+				ewutils.active_restrictions[challengee.id_user] = 0
 
 				challenger.persist()
 				challengee.persist()
@@ -1316,11 +1317,11 @@ async def russian_roulette(cmd):
 	challenger = EwUser(member = author)
 	challengee = EwUser(member = member)
 
-	challenger.rr_challenger = ""
-	challengee.rr_challenger = ""
+	ewutils.active_target_map[challenger.id_user] = ""
+	ewutils.active_target_map[challengee.id_user] = ""
 
-	challenger.rr_restriction = 0
-	challengee.rr_restriction = 0
+	ewutils.active_restrictions[challenger.id_user] = 0
+	ewutils.active_restrictions[challengee.id_user] = 0
 
 	challenger.persist()
 	challengee.persist()
@@ -1347,11 +1348,11 @@ async def duel(cmd):
 	challengee = EwUser(member=member)
 
 	# Players have been challenged
-	if challenger.rr_challenger != "":
+	if ewutils.active_target_map.get(challenger.id_user) != None and ewutils.active_target_map.get(challenger.id_user) != "":
 		response = "You are already in the middle of a challenge."
 		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
 
-	if challengee.rr_challenger != "":
+	if ewutils.active_target_map.get(challengee.id_user) != None and ewutils.active_target_map.get(challengee.id_user) != "":
 		response = "{} is already in the middle of a challenge.".format(member.display_name).replace("@", "\{at\}")
 		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
 
@@ -1365,25 +1366,26 @@ async def duel(cmd):
 		if challenger.life_state == ewcfg.life_state_corpse:
 			response = "Ghosts can't duel people. Alas, they can only watch from afar and !haunt."
 			return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
-
 		elif challengee.life_state == ewcfg.life_state_corpse:
 			response = "Ghosts can't duel people. Alas, they can only watch from afar and !haunt."
 			return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
-
+		elif challenger.life_state == ewcfg.life_state_kingpin:
+			response = "Throwing all of your gang's hard earned slime on the line strikes you as a bad idea..."
+			return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
+		elif challengee.life_state == ewcfg.life_state_kingpin:
+			response = "They think about accepting for a moment, but then back away, remembering all the hard work their gangsters have put forth. Bummer..."
+			return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
 		else:
 			response = "Juveniles are too cowardly to throw their lives away in a duel."
 			return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
 
 	# Assign a challenger so players can't be challenged
-	challenger.rr_challenger = challenger.id_user
-	challengee.rr_challenger = challenger.id_user
+	ewutils.active_target_map[challenger.id_user] = challengee.id_user
+	ewutils.active_target_map[challengee.id_user] = challenger.id_user
 	
 	# Apply restrictions to prevent movement, !tp, etc. This also lets the !accept command differentiate RR from duels.
-	challenger.rr_restriction = 2
-	challengee.rr_restriction = 2
-
-	challenger.persist()
-	challengee.persist()
+	ewutils.active_restrictions[challenger.id_user] = 2
+	ewutils.active_restrictions[challengee.id_user] = 2
 
 	response = "You have been challenged by {} to a duel. Do you !accept or !refuse?".format(author.display_name).replace("@", "\{at\}")
 	await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(member, response))
@@ -1403,21 +1405,30 @@ async def duel(cmd):
 	if accepted == 1:
 		challenger = EwUser(member=author)
 		challengee = EwUser(member=member)
-
-		challenger.persist()
-		challengee.persist()
 		
-		# start the countdown. if either user tries anything funny before the countdown is over, blow their heads clean off via BHB
+		# Start the countdown. Set restriction level to 3, which causes either user to die if they type during the countdown. 
+		ewutils.active_restrictions[challenger.id_user] = 3
+		ewutils.active_restrictions[challengee.id_user] = 3
+		
 		countdown = 10
 		
 		while countdown != 0:
-			text_mod = ""
+			# check if either user has had their restriction level set back to 0, indicating a death.
+			if ewutils.active_restrictions[challenger.id_user] == 0 or ewutils.active_restrictions[challengee.id_user] == 0:
+				ewutils.active_target_map[challenger.id_user] = ""
+				ewutils.active_target_map[challengee.id_user] = ""
+
+				ewutils.active_restrictions[challenger.id_user] = 0
+				ewutils.active_restrictions[challengee.id_user] = 0
+				
+				response = "The duel is over before it even began."
+				return await ewutils.send_message(cmd.client, cmd.message.channel, response)
 			
 			if countdown > 8:
 				text_mod = ""
 			elif countdown > 6:
 				text_mod = "*"
-			elif countdown > 4:
+			elif countdown > 3:
 				text_mod = "**"
 			else:
 				text_mod = "***"
@@ -1429,59 +1440,17 @@ async def duel(cmd):
 				
 			countdown -= 1
 			await ewutils.send_message(cmd.client, cmd.message.channel, countdown_resp)
+			await asyncio.sleep(1)
+			challenger = EwUser(member=author)
+			challengee = EwUser(member=member)
 
-			try:
-				msg = await cmd.client.wait_for_message(timeout=1, author=author)
-
-				if msg != None:
-					
-					challenger.rr_challenger = ""
-					challengee.rr_challenger = ""
-
-					challenger.rr_restriction = 0
-					challengee.rr_restriction = 0
-
-					challengee.persist()
-					
-					die_resp = challenger.die(cause=ewcfg.cause_praying)
-					challenger.persist()
-					await ewrolemgr.updateRoles(client=cmd.client, member=author)
-					await die_resp.post()
-
-					response = "ENDLESS WAR completely and utterly obliterates {} with a bone-hurting beam. The duel is over before it even began.".format(author.display_name).replace("@","\{at\}")
-					
-					return await ewutils.send_message(cmd.client, cmd.message.channel, response)
-
-
-			except:
-				pass
-
-			try:
-				msg = await cmd.client.wait_for_message(timeout=1, author=member)
-
-				if msg != None:
-					challenger.rr_challenger = ""
-					challengee.rr_challenger = ""
-
-					challenger.rr_restriction = 0
-					challengee.rr_restriction = 0
-
-					challenger.persist()
-
-					die_resp = challengee.die(cause=ewcfg.cause_praying)
-					challengee.persist()
-					await ewrolemgr.updateRoles(client=cmd.client, member=member)
-					await die_resp.post()
-
-					response = "ENDLESS WAR completely and utterly obliterates {} with a bone-hurting beam. The duel is over before it even began.".format(member.display_name).replace("@", "\{at\}")
-
-					return await ewutils.send_message(cmd.client, cmd.message.channel, response)
-
-			except:
-				pass
+		ewutils.active_restrictions[challenger.id_user] = 2
+		ewutils.active_restrictions[challengee.id_user] = 2
 			
 		response = "{}***DRAW!***{}".format(ewcfg.emote_slimegun, ewcfg.emote_slimegun)
 		await ewutils.send_message(cmd.client, cmd.message.channel, response)
+		challenger = EwUser(member=author)
+		challengee = EwUser(member=member)
 		
 		# start the duel
 		challenger.time_expirpvp = ewutils.calculatePvpTimer(challenger.time_expirpvp, (int(time.time()) + ewcfg.time_pvp_duel))
@@ -1492,6 +1461,8 @@ async def duel(cmd):
 
 		await ewrolemgr.updateRoles(client=cmd.client, member=author)
 		await ewrolemgr.updateRoles(client=cmd.client, member=member)
+		challenger = EwUser(member=author)
+		challengee = EwUser(member=member)
 		
 		duel_timer = ewcfg.time_pvp_duel
 		
@@ -1501,19 +1472,19 @@ async def duel(cmd):
 		while challenger_slimes > 0 and challengee_slimes > 0 and duel_timer > 0:
 			# count down from 2 minutes, the max possible time a duel should last
 			duel_timer -= 1
+			await asyncio.sleep(1)
 
 			# re-grab slime counts from both duelers
 			challenger = EwUser(member=author)
 			challengee = EwUser(member=member)
 			challenger_slimes = challenger.slimes
 			challengee_slimes = challengee.slimes
-
-			await asyncio.sleep(1)
 			
 		if challenger.slimes <= 0:
 			# challenger lost
 			response = "**{} has won the duel!!**".format(member.display_name).replace("@","\{at\}")
 			await ewutils.send_message(cmd.client, cmd.message.channel, response)
+			challengee = EwUser(member=member)
 
 			challengee.time_expirpvp -= duel_timer
 
@@ -1521,6 +1492,7 @@ async def duel(cmd):
 			# challengee lost
 			response = "**{} has won the duel!!**".format(author.display_name).replace("@","\{at\}")
 			await ewutils.send_message(cmd.client, cmd.message.channel, response)
+			challenger = EwUser(member=author)
 
 			challenger.time_expirpvp -= duel_timer
 		
@@ -1541,11 +1513,11 @@ async def duel(cmd):
 	challenger = EwUser(member=author)
 	challengee = EwUser(member=member)
 
-	challenger.rr_challenger = ""
-	challengee.rr_challenger = ""
+	ewutils.active_target_map[challenger.id_user] = ""
+	ewutils.active_target_map[challengee.id_user] = ""
 
-	challenger.rr_restriction = 0
-	challengee.rr_restriction = 0
+	ewutils.active_restrictions[challenger.id_user] = 0
+	ewutils.active_restrictions[challengee.id_user] = 0
 
 	challenger.persist()
 	challengee.persist()
@@ -1685,7 +1657,7 @@ def check_skat_bid(message):
 	content = message.content.lower()
 	if content.startswith(ewcfg.cmd_slimeskat_bid) or content.startswith(ewcfg.cmd_slimeskat_pass):
 
-	        # tokenize the message. the command should be the first word.
+			# tokenize the message. the command should be the first word.
 		try:
 			tokens = shlex.split(message.content)  # it's split with shlex now because shlex regards text within quotes as a single token
 		except:
@@ -1707,7 +1679,7 @@ def check_skat_call(message):
 	content = message.content.lower()
 	if content.startswith(ewcfg.cmd_slimeskat_call) or content.startswith(ewcfg.cmd_slimeskat_pass):
 
-	        # tokenize the message. the command should be the first word.
+			# tokenize the message. the command should be the first word.
 		try:
 			tokens = shlex.split(message.content)  # it's split with shlex now because shlex regards text within quotes as a single token
 		except:
@@ -1737,7 +1709,7 @@ def skat_putback(message, hand, skat):
 	content = message.content.lower()
 	putback = False
 
-        # tokenize the message. the command should be the first word.
+		# tokenize the message. the command should be the first word.
 	try:
 		tokens = shlex.split(message.content)  # it's split with shlex now because shlex regards text within quotes as a single token
 	except:
@@ -1772,7 +1744,7 @@ def check_skat_play(message):
 
 def get_skat_play(message,hand):
 	content = message.content.lower()
-        # tokenize the message. the command should be the first word.
+		# tokenize the message. the command should be the first word.
 	try:
 		tokens = shlex.split(content)  # it's split with shlex now because shlex regards text within quotes as a single token
 	except:
@@ -1908,15 +1880,15 @@ async def skat(cmd):
 			break
 
 	#Players have been challenged
-	if challenger.rr_challenger != "":
+	if ewutils.active_target_map.get(challenger.id_user) != None and ewutils.active_target_map.get(challenger.id_user) != "":
 		response = "You are already in the middle of a challenge."
 		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
 
-	if challengee.rr_challenger != "":
+	if ewutils.active_target_map.get(challengee.id_user) != None and ewutils.active_target_map.get(challengee.id_user) != "":
 		response = "{} is already in the middle of a challenge.".format(member.display_name).replace("@", "\{at\}")
 		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
 
-	if challengee2.rr_challenger != "":
+	if ewutils.active_target_map.get(challengee2.id_user) != None and ewutils.active_target_map.get(challengee2.id_user) != "":
 		response = "{} is already in the middle of a challenge.".format(member2.display_name).replace("@", "\{at\}")
 		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
 
@@ -1938,8 +1910,7 @@ async def skat(cmd):
 
 	for m in members:
 		ewuser = EwUser(member = m)
-		ewuser.rr_challenger = ""
-		ewuser.persist()
+		ewutils.active_target_map[ewuser.id_user] = ""
 
 	response = "You have been invited by {} to a game of slime skat. Do you {} or {}?".format(author.display_name,ewcfg.cmd_slimeskat_join,ewcfg.cmd_slimeskat_decline).replace("@", "\{at\}")
 	await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(member, response))
@@ -1960,11 +1931,10 @@ async def skat(cmd):
 		await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
 		for m in members:
 			ewuser = EwUser(member = m)
-			ewuser.rr_challenger = ""
-			ewuser.persist()
+			ewutils.active_target_map[ewuser.id_user] = ""
 
 		return
-        
+		
 	response = "You have been invited by {} to a round of slime skat. Do you {} or {}?".format(author.display_name,ewcfg.cmd_slimeskat_join,ewcfg.cmd_slimeskat_decline).replace("@", "\{at\}")
 	await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(member2, response))
 
@@ -1978,14 +1948,13 @@ async def skat(cmd):
 				accepted = 1
 	except:
 		accepted = 0
-                
+				
 	if accepted == 0:	
 		response = "{}'s brain was too small to understand slime skat.".format(member2.display_name).replace("@", "\{at\}")
 		await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(author, response))
 		for m in members:
 			ewuser = EwUser(member = m)
-			ewuser.rr_challenger = ""
-			ewuser.persist()
+			ewutils.active_target_map[ewuser.id_user] = ""
 
 		return
 	
@@ -2000,8 +1969,7 @@ async def skat(cmd):
 				response = "You don't have enough slimecoin to cover your potential loss. Try lowering the multiplier."
 				for m in members:
 					ewuser = EwUser(member = m)
-					ewuser.rr_challenger = ""
-					ewuser.persist()
+					ewutils.active_target_map[ewuser.id_user] = ""
 				return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(members[i], response))
 
 		front_idx = (round_num + 0) % 3
@@ -2121,7 +2089,7 @@ async def skat(cmd):
 				passed = True
 			await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(members[active_idx],response))
 			if passed == True:
-			    active_idx = back_idx
+				active_idx = back_idx
 
 		#potential round 3
 		if maxbid < 18:
@@ -2398,71 +2366,70 @@ async def skat(cmd):
 	await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(members[active_idx], response))
 	for m in members:
 		ewuser = EwUser(member = m)
-		ewuser.rr_challenger = ""
-		ewuser.persist()
+		ewutils.active_target_map[ewuser.id_user] = ""
 
 	return
 
 
 """ Join a slime skat round """
 async def skat_join(cmd):
-        return
+		return
 
 """ Decline joining a slime skat round """
 async def skat_decline(cmd):
-        return
+		return
 
 """ Bid in slime skat """
 async def skat_bid(cmd):
-        return
+		return
 
 """ Pass on a bid in slime skat """
 async def skat_pass(cmd):
-        return
+		return
 
 """ Call on a bid in slime skat """
 async def skat_call(cmd):
-        return
+		return
 
 """ Play a card in slime skat """
 async def skat_play(cmd):
-        return
+		return
 
 """ Play a suit game with hearts as trump in slime skat """
 async def skat_hearts(cmd):
-        return
+		return
 
 """ Play a suit game with slugs as trump in slime skat """
 async def skat_slugs(cmd):
-        return
+		return
 
 """ Play a suit game with hats as trump in slime skat """
 async def skat_hats(cmd):
-        return
+		return
 
 """ Play a suit game with shields as trump in slime skat """
 async def skat_shields(cmd):
-        return
+		return
 
 """ Play a grand game in slime skat """
 async def skat_grand(cmd):
-        return
+		return
 
 """ Play a null game in slime skat """
 async def skat_null(cmd):
-        return
+		return
 
 """ Take the skat """
 async def skat_take(cmd):
-        return
+		return
 
 """ Play hand (without the skat) in slime skat """
 async def skat_hand(cmd):
-        return
+		return
 
 """ Choose 1 or 2 cards to put back into the skat """
 async def skat_choose(cmd):
-        return
+		return
 
 async def betsoul(cmd):
 	usermodel = EwUser(id_user=cmd.message.author.id, id_server=cmd.message.server.id)

--- a/ewcfg.py
+++ b/ewcfg.py
@@ -529,6 +529,7 @@ cmd_shoot_alt1 = cmd_prefix + 'bonk'
 cmd_shoot_alt2 = cmd_prefix + 'pat'
 cmd_shoot_alt3 = cmd_prefix + 'ban'
 cmd_shoot_alt4 = cmd_prefix + 'pullthetrigger'
+cmd_shoot_alt5 = cmd_prefix + 'curbstomp'
 cmd_attack = cmd_prefix + 'attack'
 cmd_reload = cmd_prefix + 'reload'
 cmd_reload_alt1 = cmd_prefix + 'loadthegun'
@@ -669,6 +670,7 @@ cmd_makecostume = cmd_prefix + 'makecostume'
 cmd_trick = cmd_prefix + 'trick'
 cmd_treat = cmd_prefix + 'treat'
 cmd_russian = cmd_prefix + 'russianroulette'
+cmd_duel = cmd_prefix + 'duel'
 cmd_accept = cmd_prefix + 'accept'
 cmd_refuse = cmd_prefix + 'refuse'
 cmd_sign = cmd_prefix + 'sign'
@@ -1206,6 +1208,7 @@ time_pvp_farm = 10 * 60
 time_pvp_spar = 5 * 60
 time_pvp_enlist = 5 * 60
 time_pvp_knock = 10 #temp fix. will probably add spam prevention or something funny like restraining orders later
+time_pvp_duel = 3 * 60
 
 # time to get kicked out of subzone
 time_kickout = 60 * 60  # 1 hour

--- a/ewcfg.py
+++ b/ewcfg.py
@@ -25,7 +25,7 @@ from ewdungeons import EwDungeonScene
 import ewdebug
 
 # Global configuration options.
-version = "v3.20noslimernalia"
+version = "v3.21dds"
 
 dir_msgqueue = 'msgqueue'
 

--- a/ewcfg.py
+++ b/ewcfg.py
@@ -1480,8 +1480,6 @@ col_faction = 'faction'
 col_poi = 'poi'
 col_life_state = 'life_state'
 col_busted = 'busted'
-col_rrchallenger = 'rr_challenger_id'
-col_rr_restriction = 'rr_restriction'
 col_time_last_action = 'time_last_action'
 col_weaponmarried = 'weaponmarried'
 col_time_lastscavenge = 'time_lastscavenge'
@@ -14919,7 +14917,14 @@ curse_responses = [ # scold the player for swearing
 	"Another one for the swear jar...",
 	"Do you kiss your mother with that mouth?",
 	"Wow, maybe next time be a little nicer, won't you?",
-	"If you don't have anything nice to say, then don't say anything at all."
+	"If you don't have anything nice to say, then don't say anything at all.",
+	"Wow, racist much???",
+	"Now that's just plain rude.",
+	"And just like that, a billion SlimeCoin down the drain.",
+	"Calm down that attitude of yours, will you?",
+	"Your bad manners have costed you 1 billion SlimeCoin!",
+	"Take your anger out on a juvenile, if you're so inclined to use such vulgar language.",
+	#"You know, don't, say, s-swears."
 ]
 
 # lists of all the discord server objects served by bot, identified by the server id

--- a/ewcfg.py
+++ b/ewcfg.py
@@ -14805,7 +14805,7 @@ dance_responses = [
 	"{} starts flossing fast and hard!",
 	"{} does the Orange Justice, nailing each step flawlessly. Incredible!",
 	"{} cracks the whip! Watch them go at it!",
-	"{} performs the naenae! https://en.wikipedia.org/wiki/Nae_Nae",
+	"{} performs the Nae Nae! https://en.wikipedia.org/wiki/Nae_Nae",
 	"{} does the Default Dance! You hear the familiar Fortnite jingle go off in your head.",
 	"{} gets down on the floor and does the worm! Their rhythm is off the charts!",
 	"{} spins around like a Laotian Toprock dancer! Whoa, be careful not to kick anyone, big guy!",

--- a/ewcfg.py
+++ b/ewcfg.py
@@ -1478,6 +1478,7 @@ col_poi = 'poi'
 col_life_state = 'life_state'
 col_busted = 'busted'
 col_rrchallenger = 'rr_challenger_id'
+col_rr_restriction = 'rr_restriction'
 col_time_last_action = 'time_last_action'
 col_weaponmarried = 'weaponmarried'
 col_time_lastscavenge = 'time_lastscavenge'
@@ -1499,6 +1500,8 @@ col_has_soul = 'has_soul'
 col_sap = 'sap'
 col_hardened_sap = 'hardened_sap'
 col_manuscript = "manuscript"
+col_swear_jar = 'swear_jar'
+
 #SLIMERNALIA
 col_festivity = 'festivity'
 col_festivity_from_slimecoin = 'festivity_from_slimecoin'
@@ -5611,6 +5614,9 @@ food_list = [
 	),
 	EwFood(
 		id_food = "khaotickilliflowerfuckenergy",
+		alias = [
+			"kkfu"
+		],
 		recover_hunger = 1200,
 		price = 12000,
 		inebriation = 1000,
@@ -5621,6 +5627,9 @@ food_list = [
 	),
 	EwFood(
 		id_food = "rampagingrowddishfuckenergy",
+		alias = [
+			"rrfu"
+		],
 		recover_hunger = 1200,
 		price = 12000,
 		inebriation = 1000,
@@ -5631,6 +5640,9 @@ food_list = [
 	),
 	EwFood(
 		id_food = "direappleciderfuckenergy",
+		alias = [
+			"dacfu"
+		],
 		recover_hunger = 1200,
 		price = 12000,
 		inebriation = 1000,
@@ -5641,6 +5653,9 @@ food_list = [
 	),
 	EwFood(
 		id_food = "ultimateurinefuckenergy",
+		alias = [
+			"uufu"
+		],
 		recover_hunger = 1200,
 		price = 12000,
 		inebriation = 1000,
@@ -5651,6 +5666,9 @@ food_list = [
 	),
 	EwFood(
 		id_food = "superwaterfuckenergy",
+		alias = [
+			"swfu"
+		],
 		recover_hunger = 1200,
 		price = 12000,
 		inebriation = 1000,
@@ -14842,7 +14860,26 @@ zine_commands = [
 	cmd_setpages,
 	cmd_setpages_alt_1,
 	cmd_setpages_alt_2,
-	]
+]
+
+curse_words = [ # words that the player should be punished for saying via swear jar deduction
+	"fag",
+	"shit",
+	"ass",
+	"cunt",
+	"fuck",
+	"bitch",
+	"bastard",
+	"nigger"
+]
+
+curse_responses = [ # scold the player for swearing
+	"Watch your language!",
+	"Another one for the swear jar...",
+	"Do you kiss your mother with that mouth?",
+	"Wow, try again, but be a little nicer this time, won't you?",
+	"If you don't have anything nice to say, then don't say anything at all."
+]
 
 # lists of all the discord server objects served by bot, identified by the server id
 server_list = {}

--- a/ewcfg.py
+++ b/ewcfg.py
@@ -14898,7 +14898,20 @@ curse_words = [ # words that the player should be punished for saying via swear 
 	"fuck",
 	"bitch",
 	"bastard",
-	"nigger"
+	"nigger",
+	"kike",
+	"cuck",
+	"chink",
+	"chinaman",
+	"gook",
+	"injun",
+	"bomboclaat",
+	"mick",
+	"pickaninny",
+	"tarbaby",
+	"towelhead",
+	"wetback",
+	"zipperhead",
 ]
 
 curse_responses = [ # scold the player for swearing

--- a/ewcfg.py
+++ b/ewcfg.py
@@ -14801,10 +14801,35 @@ pray_responses_list = [
 dance_responses = [
 	"{} busts a move. Wow, look at 'em go!",
 	"{} gets down and boogies! Groovy!",
-	"{} does a headstand and starts breakdancing!",
+	"{} does a headstand and does a 720 degree spin!",
 	"{} starts flossing fast and hard!",
 	"{} does the Orange Justice, nailing each step flawlessly. Incredible!",
+	"{} cracks the whip! Watch them go at it!",
+	"{} performs the naenae! https://en.wikipedia.org/wiki/Nae_Nae",
+	"{} does the Default Dance! You hear the familiar Fortnite jingle go off in your head.",
+	"{} gets down on the floor and does the worm! Their rhythm is off the charts!",
+	"{} spins around like a Laotian Toprock dancer! Whoa, be careful not to kick anyone, big guy!",
+	"{} does the monkey! Man, they're pretty!",
+	"{} does the charleston. What is this, the 20's? They do look kinda cool though...",
+	"{} starts breakdancing, Capoeira style! They almost knock someone's teeth out with their swift leg swings!",
+	"{} does a triple backflip! Hot diggedy!",
+	"{} performs a double Cartwheel! Not really a dance move, but we'll take it!",
+	"{} starts a Conga line! The party's over here!",
+	"{} does a moonwalk! They're smooth as heck!",
+	"{} does the robot! They manage to pull it off in a way that doesn't seem totally autistic!",
+	"{} does the carlton! It's anything BUT unusual!",
+	"{} starts tap dancing! They really start puttin' on the ritz for sure!",
+	"{} pumps their fist in the air over and over!",
+	"{} does a Flamenco dance! Their grace and elegance is unmatched!",
+	"{} walks like an Egyptian! Wow, racist much???",
+	"{} does an old-fashioned breakdance! Hot damn!",
+	"{} does the traditional Ukrainian Hopak! Their legs flail back and forth!",
+	"{} performs the Mannrobics taunt! They feel the burn!",
+	"{} gets the urge to !dab, but holds back with all their might.",
+	"{} gets the urge to !thrash, but holds back with all their might.",
+	"{} just kind of stands there, awkwardly. What did you expect?",
 	"{} makes a complete fool of themselves. Everyone gets secondhand embarrassment...",
+	# "{} does the Mayor Pete dance!", -- hm, maybe not... 
 ]
 
 # list of genres and aliases
@@ -14868,7 +14893,7 @@ zine_commands = [
 curse_words = [ # words that the player should be punished for saying via swear jar deduction
 	"fag",
 	"shit",
-	"ass",
+	"asshole", # can not be shortened to 'ass' due to words like 'pass' or 'class'
 	"cunt",
 	"fuck",
 	"bitch",
@@ -14880,7 +14905,7 @@ curse_responses = [ # scold the player for swearing
 	"Watch your language!",
 	"Another one for the swear jar...",
 	"Do you kiss your mother with that mouth?",
-	"Wow, try again, but be a little nicer this time, won't you?",
+	"Wow, maybe next time be a little nicer, won't you?",
 	"If you don't have anything nice to say, then don't say anything at all."
 ]
 

--- a/ewcmd.py
+++ b/ewcmd.py
@@ -223,8 +223,23 @@ def gen_data_text(
 					response_block += status_flavor.str_describe + " "
 
 		if (slimeoid.life_state == ewcfg.slimeoid_state_active) and (user_data.life_state != ewcfg.life_state_corpse):
-			response_block += "They are accompanied by {}, a {}-foot-tall Slimeoid.".format(slimeoid.name,
-																							str(slimeoid.level))
+			response_block += "They are accompanied by {}, a {}-foot-tall Slimeoid.".format(slimeoid.name, str(slimeoid.level))
+			
+		if user_data.swear_jar >= 500:
+			response_block += "They're going to The Underworld for the things they've said."
+		elif user_data.swear_jar >= 100:
+			response_block += "They swear like a sailor!"
+		elif user_data.swear_jar >= 50:
+			response_block += "They have quite a profane vocabulary."
+		elif user_data.swear_jar >= 10:
+			response_block += "They've said some naughty things in the past."
+		elif user_data.swear_jar >= 5:
+			response_block += "They've cussed a handfull of times here and there."
+		elif user_data.swear_jar > 0:
+			response_block += "They've sworn only a few times."
+		else:
+			response_block += "Their mouth is clean as a whistle."
+			
 		if len(response_block) > 0:
 			response += "\n" + response_block
 
@@ -345,8 +360,23 @@ async def data(cmd):
 					response_block += status_flavor.str_describe_self + " "
 
 		if (slimeoid.life_state == ewcfg.slimeoid_state_active) and (user_data.life_state != ewcfg.life_state_corpse):
-			response_block += "You are accompanied by {}, a {}-foot-tall Slimeoid. ".format(slimeoid.name,
-																							str(slimeoid.level))
+			response_block += "You are accompanied by {}, a {}-foot-tall Slimeoid. ".format(slimeoid.name, str(slimeoid.level))
+		
+		if user_data.swear_jar >= 500:
+			response_block += "You're going to The Underworld for the things you've said."
+		elif user_data.swear_jar >= 100:
+			response_block += "You swear like a sailor!"
+		elif user_data.swear_jar >= 50:
+			response_block += "You have quite a profane vocabulary."
+		elif user_data.swear_jar >= 10:
+			response_block += "You've said some naughty things in the past."
+		elif user_data.swear_jar >= 5:
+			response_block += "You've cussed a handfull of times here and there."
+		elif user_data.swear_jar > 0:
+			response_block += "You've sworn only a few times."
+		else:
+			response_block += "Your mouth is clean as a whistle."
+			
 
 		if len(response_block) > 0:
 			response += "\n" + response_block
@@ -913,6 +943,7 @@ async def pray(cmd):
 
 	if cmd.message.channel.name != ewcfg.channel_endlesswar:
 		response = "You must be in the presence of your lord if you wish to pray to him."
+		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
 
 	if user_data.life_state == ewcfg.life_state_kingpin:
 		await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(
@@ -985,6 +1016,10 @@ async def pray(cmd):
 		probabilityofpoudrin = 10
 		probabilityofdeath = 10
 		diceroll = random.randint(1, 100)
+
+		# Redeem the player for their sins.
+		user_data.swear_jar = max(0, user_data.swear_jar - 1)
+		user_data.persist()
 
 		if diceroll < probabilityofpoudrin: # Player gets a poudrin.
 			item = random.choice(ewcfg.mine_results)

--- a/ewcmd.py
+++ b/ewcmd.py
@@ -766,16 +766,15 @@ async def leaderboard(cmd):
 """ Accept a russian roulette challenge """
 async def accept(cmd):
 	user = EwUser(member = cmd.message.author)
-	if(user.rr_challenger != ""):
-		challenger = EwUser(id_user = user.rr_challenger, id_server = user.id_server)
-		if(user.rr_challenger != user.id_user and challenger.rr_challenger != user.id_user):
-			challenger.rr_challenger = user.id_user
-			challenger.persist()
+	if(ewutils.active_target_map.get(user.id_user) != None and ewutils.active_target_map.get(user.id_user) != ""):
+		challenger = EwUser(id_user = ewutils.active_target_map[user.id_user], id_server = user.id_server)
+		if(ewutils.active_target_map.get(user.id_user) != user.id_user and ewutils.active_target_map.get(challenger.id_user) != user.id_user):
+			ewutils.active_target_map[challenger.id_user] = user.id_user
 			slimeoid_data = EwSlimeoid(member = cmd.message.author)
 			response = ""
 			if cmd.message.channel.name == ewcfg.channel_arena and ewslimeoid.active_slimeoidbattles.get(slimeoid_data.id_slimeoid):
 				response = "You accept the challenge! Both of your Slimeoids ready themselves for combat!"
-			elif cmd.message.channel.name == ewcfg.channel_casino and challenger.rr_restriction == 1:
+			elif cmd.message.channel.name == ewcfg.channel_casino and ewutils.active_restrictions[challenger.id_user] == 1:
 				response = "You accept the challenge! Both of you head out back behind the casino and load a bullet into the gun."
 
 			if len(response) > 0:
@@ -786,20 +785,18 @@ async def accept(cmd):
 async def refuse(cmd):
 	user = EwUser(member = cmd.message.author)
 
-	if(user.rr_challenger != ""):
-		challenger = EwUser(id_user = user.rr_challenger, id_server = user.id_server)
+	if(ewutils.active_target_map.get(user.id_user) != None and ewutils.active_target_map.get(user.id_user) != ""):
+		challenger = EwUser(id_user = ewutils.active_target_map[user.id_user], id_server = user.id_server)
 
-		user.rr_challenger = ""
-		user.rr_restriction = 0
-		user.persist()
+		ewutils.active_target_map[user.id_user] = ""
+		ewutils.active_restrictions[user.id_user] = 0
 
-		if(user.rr_challenger != user.id_user and challenger.rr_challenger != user.id_user):
+		if(ewutils.active_target_map.get(user.id_user) != user.id_user and ewutils.active_target_map.get(challenger.id_user) != user.id_user):
 			response = "You refuse the challenge, but not before leaving a large puddle of urine beneath you."
 			await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
 		else:
-			challenger.rr_challenger = ""
-			challenger.rr_restriction = 0
-			challenger.persist()
+			ewutils.active_target_map[challenger.id_user] = ""
+			ewutils.active_restrictions[challenger.id_user] = 0
 
 """
 	Ban a player from participating in the game

--- a/ewcmd.py
+++ b/ewcmd.py
@@ -775,7 +775,7 @@ async def accept(cmd):
 			response = ""
 			if cmd.message.channel.name == ewcfg.channel_arena and ewslimeoid.active_slimeoidbattles.get(slimeoid_data.id_slimeoid):
 				response = "You accept the challenge! Both of your Slimeoids ready themselves for combat!"
-			elif cmd.message.channel.name == ewcfg.channel_casino:
+			elif cmd.message.channel.name == ewcfg.channel_casino and challenger.rr_restriction == 1:
 				response = "You accept the challenge! Both of you head out back behind the casino and load a bullet into the gun."
 
 			if len(response) > 0:
@@ -790,6 +790,7 @@ async def refuse(cmd):
 		challenger = EwUser(id_user = user.rr_challenger, id_server = user.id_server)
 
 		user.rr_challenger = ""
+		user.rr_restriction = 0
 		user.persist()
 
 		if(user.rr_challenger != user.id_user and challenger.rr_challenger != user.id_user):
@@ -797,6 +798,7 @@ async def refuse(cmd):
 			await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
 		else:
 			challenger.rr_challenger = ""
+			challenger.rr_restriction = 0
 			challenger.persist()
 
 """

--- a/ewcmd.py
+++ b/ewcmd.py
@@ -223,7 +223,7 @@ def gen_data_text(
 					response_block += status_flavor.str_describe + " "
 
 		if (slimeoid.life_state == ewcfg.slimeoid_state_active) and (user_data.life_state != ewcfg.life_state_corpse):
-			response_block += "They are accompanied by {}, a {}-foot-tall Slimeoid.".format(slimeoid.name, str(slimeoid.level))
+			response_block += "They are accompanied by {}, a {}-foot-tall Slimeoid. ".format(slimeoid.name, str(slimeoid.level))
 			
 		if user_data.swear_jar >= 500:
 			response_block += "They're going to The Underworld for the things they've said."

--- a/ewmap.py
+++ b/ewmap.py
@@ -749,7 +749,11 @@ async def move(cmd = None, isApt = False):
 	member_object = server_data.get_member(player_data.id_user)
 
 	movement_method = ""
-	
+
+	if user_data.rr_restriction > 0:
+		response = "You can't do that right now."
+		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+
 	if poi == None:
 		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, "Never heard of it."))
 
@@ -1042,6 +1046,10 @@ async def teleport(cmd):
 	response = ""
 	resp_cont = ewutils.EwResponseContainer(id_server = cmd.message.server.id)
 	target_name = ewutils.flattenTokenListToString(cmd.tokens[1:])
+	
+	if user_data.rr_restriction > 0:
+		response = "You can't do that right now."
+		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
 
 	poi = ewcfg.id_to_poi.get(target_name)
 

--- a/ewmap.py
+++ b/ewmap.py
@@ -750,7 +750,7 @@ async def move(cmd = None, isApt = False):
 
 	movement_method = ""
 
-	if user_data.rr_restriction > 0:
+	if ewutils.active_restrictions.get(user_data.id_user) != None and ewutils.active_restrictions.get(user_data.id_user) > 0:
 		response = "You can't do that right now."
 		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
 
@@ -1047,7 +1047,7 @@ async def teleport(cmd):
 	resp_cont = ewutils.EwResponseContainer(id_server = cmd.message.server.id)
 	target_name = ewutils.flattenTokenListToString(cmd.tokens[1:])
 	
-	if user_data.rr_restriction > 0:
+	if ewutils.active_restrictions.get(user_data.id_user) != None and ewutils.active_restrictions.get(user_data.id_user) > 0:
 		response = "You can't do that right now."
 		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
 

--- a/ewslimeoid.py
+++ b/ewslimeoid.py
@@ -2178,7 +2178,7 @@ async def slimeoidbattle(cmd):
 	active_slimeoidbattles[challenger_slimeoid_id] = True
 	active_slimeoidbattles[challengee_slimeoid_id] = True
 
-	challengee.rr_challenger = challenger.id_user
+	ewutils.active_target_map[challengee.id_user] = challenger.id_user
 
 	challengee.persist()
 
@@ -2201,11 +2201,11 @@ async def slimeoidbattle(cmd):
 	challenger = EwUser(member = author)
 	challengee_slimeoid = EwSlimeoid(member = member)
 
-	challengee.rr_challenger = ""
-	challenger.rr_challenger = ""
+	ewutils.active_target_map[challengee.id_user] = ""
+	ewutils.active_target_map[challenger.id_user] = ""
 
-	challengee.persist()
-	challenger.persist()
+	#challengee.persist()
+	#challenger.persist()
 
 	if challenger_slimeoid.life_state != ewcfg.slimeoid_state_active:
 		active_slimeoidbattles[challenger_slimeoid_id] = False

--- a/ewtransport.py
+++ b/ewtransport.py
@@ -226,7 +226,7 @@ async def embark(cmd):
 	user_data = EwUser(member = cmd.message.author)
 	response = ""
 	
-	if user_data.rr_restriction > 0:
+	if ewutils.active_restrictions.get(user_data.id_user) != None and ewutils.active_restrictions.get(user_data.id_user) > 0:
 		response = "You can't do that right now."
 		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
 

--- a/ewtransport.py
+++ b/ewtransport.py
@@ -225,6 +225,10 @@ async def embark(cmd):
 
 	user_data = EwUser(member = cmd.message.author)
 	response = ""
+	
+	if user_data.rr_restriction > 0:
+		response = "You can't do that right now."
+		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
 
 	poi = ewmap.fetch_poi_if_coordless(cmd.message.channel.name)
 

--- a/ewutils.py
+++ b/ewutils.py
@@ -42,6 +42,11 @@ active_trades = {}
 # Contains the items being offered by players
 trading_offers = {}
 
+# Map of users to their target. This includes apartments, potential Russian Roulette players, potential Slimeoid Battle players, etc. 
+active_target_map = {}
+# Map of users to their restriction level, typically in a mini-game. This prevents people from moving, teleporting, boarding, retiring, or suiciding in Russian Roulette/Duels
+active_restrictions = {}
+
 class Message:
 	# Send the message to this exact channel by name.
 	channel = None

--- a/ewwep.py
+++ b/ewwep.py
@@ -1048,8 +1048,8 @@ async def suicide(cmd):
 		elif user_isgeneral:
 			response = "\*click* Alas, your gun has jammed."
 		elif user_iskillers or user_isrowdys or user_isexecutive or user_islucky or user_isjuvenile:
-			if user_data.rr_challenger != "":
-				response = "You can't do that now."
+			if user_data.rr_restriction > 0:
+				response = "You can't do that right now."
 				return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response)) 
 
 			slimes_total = user_data.slimes

--- a/ewwep.py
+++ b/ewwep.py
@@ -1048,7 +1048,7 @@ async def suicide(cmd):
 		elif user_isgeneral:
 			response = "\*click* Alas, your gun has jammed."
 		elif user_iskillers or user_isrowdys or user_isexecutive or user_islucky or user_isjuvenile:
-			if user_data.rr_restriction > 0:
+			if ewutils.active_restrictions.get(user_data.id_user) != None and ewutils.active_restrictions.get(user_data.id_user) > 0:
 				response = "You can't do that right now."
 				return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response)) 
 


### PR DESCRIPTION
- Added in Duels
- To initiate a duel, you must use !duel on another player. If they !accept, this will flag both of you for 3 minutes after a 10 second countdown.
- If either player sends a message to the server during the countdown, they will be struck by the Bone Hurting Beam, and the duel will end immediately.
- You can not !move, !embark, !teleport, or !retire during a duel. (This also applies to Russian Roulette)
- Added in more than 20 new dance moves.
- Added in the Swear Jar. Swearing within the server or in ENDLESS WAR's DMs will deduct 1 billion slimecoin from you, and will increase your Swear Jar by 1.
- To lower your swear jar, you must !pray
- !curbstomp is now an alias for !kill